### PR TITLE
Adjust reductions based on ply+1's fail-high count

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -436,12 +436,12 @@ int Search::SearchRecursive(Board& board, int depth, const int level, int alpha,
 			return get<1>(t1) > get<1>(t2);
 		});
 
-		// Resetting killers and fail-high cutoff counts for ply+2
+		// Resetting killers and fail-high cutoff counts
 		if (level + 2 < MaxDepth) {
 			Heuristics.KillerMoves[level + 2][0] = EmptyMove;
 			Heuristics.KillerMoves[level + 2][1] = EmptyMove;
-			CutoffCount[level + 2] = 0;
 		}
+		if (level + 1 < MaxDepth) CutoffCount[level + 1] = 0;
 	}
 
 	// Iterate through legal moves

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -151,6 +151,7 @@ Results Search::SearchMoves(Board board, const SearchParams params, const Engine
 
 	SetupAccumulators(board);
 	std::fill(ExcludedMoves.begin(), ExcludedMoves.end(), EmptyMove);
+	std::fill(CutoffCount.begin(), CutoffCount.end(), 0);
 
 	// Early exit for only one legal move (no legal moves are handled separately)
 	if (!DatagenMode && ((params.wtime != 0) || (params.btime != 0))) {
@@ -435,10 +436,11 @@ int Search::SearchRecursive(Board& board, int depth, const int level, int alpha,
 			return get<1>(t1) > get<1>(t2);
 		});
 
-		// Resetting killers for ply+2
+		// Resetting killers and fail-high cutoff counts for ply+2
 		if (level + 2 < MaxDepth) {
 			Heuristics.KillerMoves[level + 2][0] = EmptyMove;
 			Heuristics.KillerMoves[level + 2][1] = EmptyMove;
+			CutoffCount[level + 2] = 0;
 		}
 	}
 
@@ -526,6 +528,9 @@ int Search::SearchRecursive(Board& board, int depth, const int level, int alpha,
 				// More reduction for non-PV nodes
 				if (!pvNode) reduction += 1;
 
+				// Less reduction when the next ply only had a few fail-highs
+				if (CutoffCount[level] < 4) reduction -= 1;
+
 				// Adjust based on history
 				if (std::abs(order) < 80000) reduction -= std::clamp(order / 8192, -2, 2);
 
@@ -553,6 +558,7 @@ int Search::SearchRecursive(Board& board, int depth, const int level, int alpha,
 
 				Statistics.BetaCutoffs += 1;
 				if (legalMoveCount == 1) Statistics.FirstMoveBetaCutoffs += 1;
+				if (level != 0) CutoffCount[level - 1] += 1;
 
 				if (!aborting) {
 

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -64,6 +64,7 @@ private:
 	std::array<int, MaxDepth> StaticEvalStack;
 	std::array<int, MaxDepth> EvalStack;
 	std::array<MoveAndPiece, MaxDepth> MoveStack;
+	std::array<int, MaxDepth> CutoffCount;
 
 	std::array<Move, MaxDepth> ExcludedMoves;
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.1.0 dev 9";
+constexpr std::string_view Version = "1.1.0 dev 10";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 6.11 +- 5.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7846 W: 1831 L: 1693 D: 4322
Penta | [53, 835, 2018, 955, 62]
https://renegadedev.eu.pythonanywhere.com/test/7/
```

1.1.0 dev 10
Bench: 2147010