### PR TITLE
Remove obsolete en passant threats code

### DIFF
--- a/Renegade/Board.cpp
+++ b/Renegade/Board.cpp
@@ -835,19 +835,6 @@ uint64_t Board::CalculateAttackedSquaresTemplated() const {
 
 	// Pawn attacks
 	map = (attackingSide == Side::White) ? GetPawnAttacks<Side::White>() : GetPawnAttacks<Side::Black>();
-	// En passant stuff (probably should be removed)
-	if constexpr (attackingSide == Side::White) {
-		if (EnPassantSquare != -1) {
-			const uint64_t encodedEP = SquareBit(EnPassantSquare);
-			map |= (((WhitePawnBits & ~File[0]) >> 1) | ((WhitePawnBits & ~File[7]) << 1)) & encodedEP;
-		}
-	}
-	else {
-		if (EnPassantSquare != -1) {
-			const uint64_t encodedEP = SquareBit(EnPassantSquare);
-			map |= (((BlackPawnBits & ~File[0]) >> 1) | ((BlackPawnBits & ~File[7]) << 1)) & encodedEP;
-		}
-	}
 
 	// Knight attacks
 	uint64_t knightBits = (attackingSide == Side::White) ? WhiteKnightBits : BlackKnightBits;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.1.0 dev 10";
+constexpr std::string_view Version = "1.1.0 dev 11";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 9.84 +- 7.74 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3392 W: 792 L: 696 D: 1904
Penta | [15, 351, 882, 419, 29]
https://renegadedev.eu.pythonanywhere.com/test/16/
```