### PR TITLE
Remove move ordering fallback when no history scores exist

### DIFF
--- a/Renegade/Heuristics.cpp
+++ b/Renegade/Heuristics.cpp
@@ -52,24 +52,7 @@ int Heuristics::CalculateOrderScore(const Board& board, const Move& m, const int
 	if (level >= 2) historyScore += (*ContinuationHistory)[moveStack[level - 2].piece][moveStack[level - 2].move.to][movedPiece][m.to];
 	if (level >= 4) historyScore += (*ContinuationHistory)[moveStack[level - 4].piece][moveStack[level - 4].move.to][movedPiece][m.to];
 
-	if (historyScore != 0) {
-		// When at least we have some history scores
-		return historyScore;
-	}
-
-	// If we have don't have history scores, we order by PSQT delta
-	// this is a very old leftover of Renegade, and probably has very little effect on strength
-	int orderScore = 0;
-	if (turn == Side::White) {
-		orderScore -= LinearTaper(Weights.GetPSQT(attackingPieceType, m.from).early, Weights.GetPSQT(attackingPieceType, m.from).late, phase);
-		orderScore += LinearTaper(Weights.GetPSQT(attackingPieceType, m.to).early, Weights.GetPSQT(attackingPieceType, m.to).late, phase);
-	}
-	else {
-		orderScore -= LinearTaper(Weights.GetPSQT(attackingPieceType, Mirror(m.from)).early, Weights.GetPSQT(attackingPieceType, Mirror(m.from)).late, phase);
-		orderScore += LinearTaper(Weights.GetPSQT(attackingPieceType, Mirror(m.to)).early, Weights.GetPSQT(attackingPieceType, Mirror(m.to)).late, phase);
-	}
-	return orderScore; // orderScore / 4 did marginally better at fixed nodes
-
+	return historyScore;
 }
 
 // PV table ---------------------------------------------------------------------------------------

--- a/Renegade/Heuristics.h
+++ b/Renegade/Heuristics.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Board.h"
-#include "Evaluation.h"
 #include "Utils.h"
 #include <algorithm>
 #include <array>

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.1.0 dev 11";
+constexpr std::string_view Version = "1.1.0 dev 12";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This removes the move ordering method that was used before the implementation of history heuristic. It was used as a fallback in the case of history score = 0 until now.

The test takes the high score for the longest running SPRT so far, easily beating the previous record of 18k games:

```
Elo   | -0.46 +- 2.21 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 43394 W: 9890 L: 9948 D: 23556
Penta | [319, 5208, 10715, 5122, 333]
```

1.1.0 dev 12
Bench: 2582202