### PR TITLE
Smaller aspiration windows, and widening it less

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -191,7 +191,7 @@ Results Search::SearchMoves(Board board, const SearchParams params, const Engine
 		}
 		else {
 			// Aspiration windows
-			int windowSize = 25;
+			int windowSize = 20;
 			int searchDepth = Depth;
 
 			while (true) {
@@ -235,7 +235,7 @@ Results Search::SearchMoves(Board board, const SearchParams params, const Engine
 					break;
 				}
 
-				windowSize *= 2;
+				windowSize += windowSize / 2;
 
 			}
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.1.0 dev 12";
+constexpr std::string_view Version = "1.1.0 dev 13";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.72 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 27894 W: 6339 L: 6121 D: 15434
Penta | [178, 3253, 6869, 3467, 180]
https://renegadedev.eu.pythonanywhere.com/test/22/
```

1.1.0 dev 13
Bench: 2169826