### PR TITLE
Double extensions

### DIFF
--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -65,7 +65,7 @@ private:
 	std::array<int, MaxDepth> EvalStack;
 	std::array<MoveAndPiece, MaxDepth> MoveStack;
 	std::array<int, MaxDepth> CutoffCount;
-
+	std::array<int, MaxDepth> DoubleExtensions;
 	std::array<Move, MaxDepth> ExcludedMoves;
 
 	std::array<std::array<int, 32>, 32> LMRTable;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.1.0 dev 13";
+constexpr std::string_view Version = "1.1.0 dev 14";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 16.67 +- 9.30 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2482 W: 634 L: 515 D: 1333
Penta | [8, 262, 599, 347, 25]
https://renegadedev.eu.pythonanywhere.com/test/24/
```

1.1.0 dev 14
Bench: 2147382