### PR TITLE
When improving, reduce move count before LMP kicks in

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -459,7 +459,7 @@ int Search::SearchRecursive(Board& board, int depth, const int level, int alpha,
 
 			// Late-move pruning (+9 elo)
 			if (isQuiet && !inCheck && (depth < 5)) {
-				const int lmpCount = 3 + depth * (depth + improving);
+				const int lmpCount = 3 + depth * (depth - !improving);
 				if (legalMoveCount > lmpCount) break;
 			}
 

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -458,8 +458,8 @@ int Search::SearchRecursive(Board& board, int depth, const int level, int alpha,
 		if (!pvNode && (bestScore > -MateThreshold) && (order < 90000) && !DatagenMode) {
 
 			// Late-move pruning (+9 elo)
-			const int lmpCount = 3 + depth * depth;
 			if (isQuiet && !inCheck && (depth < 5)) {
+				const int lmpCount = 3 + depth * (depth + improving);
 				if (legalMoveCount > lmpCount) break;
 			}
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.1.0 dev 18";
+constexpr std::string_view Version = "1.1.0 dev 19";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 5.78 +- 4.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8530 W: 2012 L: 1870 D: 4648
Penta | [43, 984, 2088, 1088, 62]
https://renegadedev.eu.pythonanywhere.com/test/37/
```

1.1.0 dev 19
Bench: 2265307