### PR TITLE
The big board logic rewrite of 2024

### DIFF
--- a/Renegade/Datagen.h
+++ b/Renegade/Datagen.h
@@ -2,7 +2,7 @@
 #include <filesystem>
 #include <fstream>
 #include <thread>
-#include "Board.h"
+#include "Position.h"
 #include "Search.h"
 #include "Settings.h"
 #include "Utils.h"
@@ -14,7 +14,7 @@ public:
 	void Start();
 	void SelfPlay(const std::string filename, const SearchParams params, const SearchParams vParams,
 		const int randomPlyBase, const int startingEvalLimit, const int threadId);
-	bool Filter(const Board& board, const Move& move, const int eval) const;
+	bool Filter(const Position& pos, const Move& move, const int eval) const;
 
 	std::string ToMarlinformat(const std::pair<std::string, int>& position, const GameState outcome) const;
 	// <fen> | <eval> | <wdl>

--- a/Renegade/Engine.cpp
+++ b/Renegade/Engine.cpp
@@ -8,7 +8,7 @@ Engine::Engine(int argc, char* argv[]) {
 	Search.Heuristics.SetHashSize(Settings::Hash);
 
 	if ((argc == 2) && (std::string(argv[1]) == "bench")) {
-		HandleBench();
+		HandleBench(false);
 		QuitAfterBench = true;
 	}
 	else PrintHeader();
@@ -346,7 +346,12 @@ void Engine::Start() {
 		}
 
 		if (parts[0] == "bench") {
-			HandleBench();
+			HandleBench(false);
+			continue;
+		}
+
+		if (parts[0] == "longbench") {
+			HandleBench(true);
 			continue;
 		}
 
@@ -421,10 +426,10 @@ void Engine::DrawBoard(const Position& position, const uint64_t customBits) cons
 
 }
 
-void Engine::HandleBench() {
+void Engine::HandleBench(const bool lengthy) {
 	uint64_t nodes = 0;
 	SearchParams params;
-	params.depth = 14;
+	params.depth = lengthy ? 22 : 14;
 	const int oldHashSize = Settings::Hash;
 	Search.Heuristics.SetHashSize(16);
 	const auto startTime = Clock::now();
@@ -437,6 +442,7 @@ void Engine::HandleBench() {
 	const auto endTime = Clock::now();
 	const int nps = static_cast<int>(nodes / ((endTime - startTime).count() / 1e9));
 	cout << nodes << " nodes " << nps << " nps" << endl;
+	Search.ResetState(false);
 	Search.Heuristics.SetHashSize(oldHashSize); // also clears the transposition table
 }
 

--- a/Renegade/Engine.cpp
+++ b/Renegade/Engine.cpp
@@ -278,7 +278,7 @@ void Engine::Start() {
 				if ((parts.size() > 2) && (parts[2] == "moves")) {
 					for (int i = 3; i < parts.size(); i++) {
 						bool r = board.PushUci(parts[i]);
-						if (!r) cout << "!!! Error: invalid pushuci move: '" << parts[i] << "' !!!" << endl;
+						if (!r) cout << "!!! Error: invalid pushuci move: '" << parts[i] << "' at position '" << board.GetFEN() <<"' !!!" << endl;
 					}
 				}
 			}

--- a/Renegade/Engine.cpp
+++ b/Renegade/Engine.cpp
@@ -429,7 +429,7 @@ void Engine::DrawBoard(const Position& position, const uint64_t customBits) cons
 void Engine::HandleBench(const bool lengthy) {
 	uint64_t nodes = 0;
 	SearchParams params;
-	params.depth = lengthy ? 22 : 14;
+	params.depth = lengthy ? 21 : 14;
 	const int oldHashSize = Settings::Hash;
 	Search.Heuristics.SetHashSize(16);
 	const auto startTime = Clock::now();

--- a/Renegade/Engine.h
+++ b/Renegade/Engine.h
@@ -22,7 +22,7 @@ public:
 	void Start();
 	void PrintHeader() const;
 	void DrawBoard(const Position &pos, const uint64_t customBits = 0) const;
-	void HandleBench();
+	void HandleBench(const bool lengthy);
 	void HandleHelp() const;
 	void HandleCompiler() const;
 

--- a/Renegade/Engine.h
+++ b/Renegade/Engine.h
@@ -1,8 +1,9 @@
 #pragma once
-#include "Board.h"
 #include "Datagen.h"
+#include "Evaluation.h"
 #include "Magics.h"
 #include "Neurals.h"
+#include "Position.h"
 #include "Reporting.h"
 #include "Search.h"
 #include "Settings.h"
@@ -20,7 +21,7 @@ public:
 	Engine(int argc, char* argv[]);
 	void Start();
 	void PrintHeader() const;
-	void DrawBoard(const Board &b, const uint64_t customBits = 0) const;
+	void DrawBoard(const Position &pos, const uint64_t customBits = 0) const;
 	void HandleBench();
 	void HandleHelp() const;
 	void HandleCompiler() const;

--- a/Renegade/Evaluation.h
+++ b/Renegade/Evaluation.h
@@ -1,10 +1,10 @@
 #pragma once
-#include "Board.h"
 #include "Move.h"
+#include "Position.h"
 
-extern uint64_t GetBishopAttacks(const uint8_t square, const uint64_t occupancy);
-extern uint64_t GetRookAttacks(const uint8_t square, const uint64_t occupancy);
-extern uint64_t GetQueenAttacks(const uint8_t square, const uint64_t occupancy);
+uint64_t GetBishopAttacks(const uint8_t square, const uint64_t occupancy);
+uint64_t GetRookAttacks(const uint8_t square, const uint64_t occupancy);
+uint64_t GetQueenAttacks(const uint8_t square, const uint64_t occupancy);
 
 struct EvaluationFeatures {
 
@@ -301,23 +301,23 @@ inline int LinearTaper(const TaperedScore& tapered, const float phase) {
 }
 
 
-inline float CalculateGamePhase(const Board& board) {
-	const int remainingPawns = Popcount(board.WhitePawnBits | board.BlackPawnBits);
-	const int remainingKnights = Popcount(board.WhiteKnightBits | board.BlackKnightBits);
-	const int remainingBishops = Popcount(board.WhiteBishopBits | board.BlackBishopBits);
-	const int remainingRooks = Popcount(board.WhiteRookBits | board.BlackRookBits);
-	const int remainingQueens = Popcount(board.WhiteQueenBits | board.BlackQueenBits);
+inline float CalculateGamePhase(const Position& position) {
+	const int remainingPawns = Popcount(position.WhitePawnBits() | position.BlackPawnBits());
+	const int remainingKnights = Popcount(position.WhiteKnightBits() | position.BlackKnightBits());
+	const int remainingBishops = Popcount(position.WhiteBishopBits() | position.BlackBishopBits());
+	const int remainingRooks = Popcount(position.WhiteRookBits() | position.BlackRookBits());
+	const int remainingQueens = Popcount(position.WhiteQueenBits() | position.BlackQueenBits());
 	const int remainingScore = remainingPawns + remainingKnights * 10 + remainingBishops * 10 + remainingRooks * 20 + remainingQueens * 40;
 	const float phase = (256 - remainingScore) / (256.f);
 	return std::clamp(phase, 0.f, 1.f);
 }
 
 
-inline bool IsDrawishEndgame(const Board& board, const uint64_t whitePieces, const uint64_t blackPieces);
+inline bool IsDrawishEndgame(const Position& position, const uint64_t whitePieces, const uint64_t blackPieces);
 
-int ClassicalEvaluate(const Board& board, const EvaluationFeatures& weights);
+int ClassicalEvaluate(const Position& position, const EvaluationFeatures& weights);
 
 
-inline int ClassicalEvaluate(const Board& board) {
-	return ClassicalEvaluate(board, Weights);
+inline int ClassicalEvaluate(const Position& position) {
+	return ClassicalEvaluate(position, Weights);
 }

--- a/Renegade/Heuristics.cpp
+++ b/Renegade/Heuristics.cpp
@@ -13,12 +13,12 @@ Heuristics::~Heuristics() {
 
 // Move ordering & clearing -----------------------------------------------------------------------
 
-int Heuristics::CalculateOrderScore(const Board& board, const Move& m, const int level, const Move& ttMove,
+int Heuristics::CalculateOrderScore(const Position& position, const Move& m, const int level, const Move& ttMove,
 	const std::array<MoveAndPiece, MaxDepth>& moveStack, const bool losingCapture, const bool useMoveStack, const uint64_t opponentAttacks) const {
 
-	const uint8_t movedPiece = board.GetPieceAt(m.from);
+	const uint8_t movedPiece = position.GetPieceAt(m.from);
 	const int attackingPieceType = TypeOfPiece(movedPiece);
-	const int capturedPieceType = TypeOfPiece(board.GetPieceAt(m.to));
+	const int capturedPieceType = TypeOfPiece(position.GetPieceAt(m.to));
 	const int values[] = { 0, 100, 300, 300, 500, 900, 0 };
 	
 	// Transposition move
@@ -47,7 +47,7 @@ int Heuristics::CalculateOrderScore(const Board& board, const Move& m, const int
 	if (level > 0 && useMoveStack && IsCountermove(moveStack[level - 1].move, m)) return 99000;
 
 	// Quiet moves
-	const bool turn = board.Turn;
+	const bool turn = position.Turn();
 
 	int historyScore = HistoryTables[CheckBit(opponentAttacks, m.from)][CheckBit(opponentAttacks, m.to)][movedPiece][m.to];
 	if (level >= 1) historyScore += (*ContinuationHistory)[moveStack[level - 1].piece][moveStack[level - 1].move.to][movedPiece][m.to];
@@ -164,7 +164,7 @@ void Heuristics::ClearHistory() {
 
 void Heuristics::AddTranspositionEntry(const uint64_t hash, const uint16_t age, const int depth, int score, const int scoreType, const Move& bestMove, const int level) {
 
-	assert(std::abs(score) > MateEval);
+	//assert(std::abs(score) > MateEval);
 	assert(HashFilter != 0);
 	if (std::abs(score) > MateEval) return;
 

--- a/Renegade/Heuristics.cpp
+++ b/Renegade/Heuristics.cpp
@@ -28,13 +28,15 @@ int Heuristics::CalculateOrderScore(const Board& board, const Move& m, const int
 	if (m.flag == MoveFlag::PromotionToQueen) return 700000 + values[capturedPieceType];
 
 	// Captures
-	if (!losingCapture) {
-		if (capturedPieceType != PieceType::None) return 600000 + values[capturedPieceType] * 16 - values[attackingPieceType];
-		if (m.flag == MoveFlag::EnPassantPerformed) return 600000 + values[PieceType::Pawn] * 16 - values[PieceType::Pawn];
-	}
-	else {
-		if (capturedPieceType != PieceType::None) return -200000 + values[capturedPieceType] * 16 - values[attackingPieceType];
-		if (m.flag == MoveFlag::EnPassantPerformed) return -200000 + values[PieceType::Pawn] * 16 - values[PieceType::Pawn];
+	if (!m.IsCastling()) {
+		if (!losingCapture) {
+			if (capturedPieceType != PieceType::None) return 600000 + values[capturedPieceType] * 16 - values[attackingPieceType];
+			if (m.flag == MoveFlag::EnPassantPerformed) return 600000 + values[PieceType::Pawn] * 16 - values[PieceType::Pawn];
+		}
+		else {
+			if (capturedPieceType != PieceType::None) return -200000 + values[capturedPieceType] * 16 - values[attackingPieceType];
+			if (m.flag == MoveFlag::EnPassantPerformed) return -200000 + values[PieceType::Pawn] * 16 - values[PieceType::Pawn];
+		}
 	}
 	
 	// Quiet killer moves

--- a/Renegade/Heuristics.h
+++ b/Renegade/Heuristics.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Board.h"
+#include "Position.h"
 #include "Utils.h"
 #include <algorithm>
 #include <array>
@@ -66,7 +66,7 @@ public:
 
 	Heuristics();
 	~Heuristics();
-	[[nodiscard]] int CalculateOrderScore(const Board& board, const Move& m, const int level, const Move& ttMove,
+	[[nodiscard]] int CalculateOrderScore(const Position& position, const Move& m, const int level, const Move& ttMove,
 		const std::array<MoveAndPiece, MaxDepth>& moveStack, const bool losingCapture, const bool useMoveStack, const uint64_t opponentAttacks) const;
 	
 	// PV table

--- a/Renegade/Magics.h
+++ b/Renegade/Magics.h
@@ -5,9 +5,9 @@
 // Methods:
 // void GenerateMagicNumbers();
 void GenerateMagicTables();
-uint64_t GetRookAttacks(const uint8_t square, const uint64_t occupancy);
-uint64_t GetBishopAttacks(const uint8_t square, const uint64_t occupancy);
-uint64_t GetQueenAttacks(const uint8_t square, const uint64_t occupancy);
+extern uint64_t GetRookAttacks(const uint8_t square, const uint64_t occupancy);
+extern uint64_t GetBishopAttacks(const uint8_t square, const uint64_t occupancy);
+extern uint64_t GetQueenAttacks(const uint8_t square, const uint64_t occupancy);
 
 // Attack lookup tables (generated at runtime)
 static std::array<std::array<uint64_t, 4096>, 64> RookAttacks;

--- a/Renegade/Move.h
+++ b/Renegade/Move.h
@@ -35,6 +35,16 @@ public:
 	std::string ToString() const {
 		if (from == 0 && to == 0) return "0000";
 
+		// Handle castling (standard)
+		if (flag == MoveFlag::ShortCastle) {
+			const bool side = from < 32 ? Side::White : Side::Black;
+			return side == Side::White ? "e1g1" : "e8g8";
+		}
+		else if (flag == MoveFlag::LongCastle) {
+			const bool side = from < 32 ? Side::White : Side::Black;
+			return side == Side::White ? "e1c1" : "e8c8";
+		}
+
 		const int file1 = from % 8;
 		const int rank1 = from / 8;
 		const int file2 = to % 8;
@@ -76,6 +86,10 @@ public:
 	inline bool IsPromotion() const {
 		return (flag == MoveFlag::PromotionToQueen) || (flag == MoveFlag::PromotionToRook)
 			|| (flag == MoveFlag::PromotionToKnight) || (flag == MoveFlag::PromotionToBishop);
+	}
+
+	inline bool IsCastling() const {
+		return flag == MoveFlag::ShortCastle || flag == MoveFlag::LongCastle;
 	}
 
 	inline uint8_t GetPromotionPieceType() const {

--- a/Renegade/Neurals.cpp
+++ b/Renegade/Neurals.cpp
@@ -65,7 +65,7 @@ int NeuralEvaluate(const AccumulatorRepresentation& acc, const bool turn) {
 	return std::clamp(output, -MateThreshold + 1, MateThreshold - 1);
 }
 
-int NeuralEvaluate(const Board& board) {
+int NeuralEvaluate(const Position& position) {
 	
 	// Initialize arrays and accumulators
 	alignas(64) std::array<int16_t, HiddenSize> hiddenWhite = std::array<int16_t, HiddenSize>();
@@ -76,14 +76,14 @@ int NeuralEvaluate(const Board& board) {
 	acc.Reset();
 
 	// Iterate through pieces and activate features
-	uint64_t bits = board.GetOccupancy();
+	uint64_t bits = position.GetOccupancy();
 	while (bits) {
 		const uint8_t sq = Popsquare(bits);
-		const int piece = board.GetPieceAt(sq);
+		const int piece = position.GetPieceAt(sq);
 		acc.AddFeature(FeatureIndexes(piece, sq));
 	}
 
-	return NeuralEvaluate(acc, board.Turn);
+	return NeuralEvaluate(acc, position.Turn());
 }
 
 void LoadExternalNetwork(const std::string& filename) {
@@ -99,8 +99,8 @@ void LoadExternalNetwork(const std::string& filename) {
 	std::swap(ExternalNetwork, loadedNetwork);
 	Network = ExternalNetwork.get();
 
-	const Board b;
-	const int startposEval = NeuralEvaluate(b);
+	const Position pos{};
+	const int startposEval = NeuralEvaluate(pos);
 	if (std::abs(startposEval) < 300 && startposEval != 0) cout << "Loaded '" << filename << "' external network probably successfully";
 	else cout << "Loaded '" << filename << "', but it stinks";
 	cout << " (startpos raw eval: " << startposEval << ")" << endl;

--- a/Renegade/Neurals.h
+++ b/Renegade/Neurals.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Board.h"
+#include "Position.h"
 #include <algorithm>
 #include <array>
 #include <fstream>
@@ -58,7 +58,7 @@ struct alignas(64) AccumulatorRepresentation {
 void LoadDefaultNetwork();
 void LoadExternalNetwork(const std::string& filename);
 
-int NeuralEvaluate(const Board &board);
+int NeuralEvaluate(const Position &position);
 int NeuralEvaluate(const AccumulatorRepresentation& acc, const bool turn);
 
 inline int32_t ClippedReLU(const int16_t value) {

--- a/Renegade/Position.cpp
+++ b/Renegade/Position.cpp
@@ -1,0 +1,713 @@
+#include "Position.h"
+
+// Constructor ------------------------------------------------------------------------------------
+
+Position::Position(const std::string& fen) {
+	const std::vector<std::string> parts = Split(fen);
+
+	// Reserve memory, add starting state
+	States.reserve(512);
+	Hashes.reserve(512);
+	States.push_back(Board());
+	Board& board = States.back();
+	
+	// Place pieces on the board
+	int square = 56;
+	for (const char& f : parts[0]) {
+		switch (f) {
+		case '/': square -= 16; break;
+		case '1': square += 1; break;
+		case '2': square += 2; break;
+		case '3': square += 3; break;
+		case '4': square += 4; break;
+		case '5': square += 5; break;
+		case '6': square += 6; break;
+		case '7': square += 7; break;
+		case '8': square += 8; break;
+		case 'P': board.AddPiece<Piece::WhitePawn>(square); square += 1; break;
+		case 'N': board.AddPiece<Piece::WhiteKnight>(square); square += 1; break;
+		case 'B': board.AddPiece<Piece::WhiteBishop>(square); square += 1; break;
+		case 'R': board.AddPiece<Piece::WhiteRook>(square); square += 1; break;
+		case 'Q': board.AddPiece<Piece::WhiteQueen>(square); square += 1; break;
+		case 'K': board.AddPiece<Piece::WhiteKing>(square); square += 1; break;
+		case 'p': board.AddPiece<Piece::BlackPawn>(square); square += 1; break;
+		case 'n': board.AddPiece<Piece::BlackKnight>(square); square += 1; break;
+		case 'b': board.AddPiece<Piece::BlackBishop>(square); square += 1; break;
+		case 'r': board.AddPiece<Piece::BlackRook>(square); square += 1; break;
+		case 'q': board.AddPiece<Piece::BlackQueen>(square); square += 1; break;
+		case 'k': board.AddPiece<Piece::BlackKing>(square); square += 1; break;
+		}
+	}
+
+	// Other information
+	board.Turn = (parts[1] == "w") ? Side::White : Side::Black;
+
+	for (const char& f : parts[2]) {
+		switch (f) {
+		case 'K': board.WhiteRightToShortCastle = true; break;
+		case 'Q': board.WhiteRightToLongCastle = true; break;
+		case 'k': board.BlackRightToShortCastle = true; break;
+		case 'q': board.BlackRightToLongCastle = true; break;
+		}
+	}
+	CastlingConfig = { 0, 7, 56, 63 };
+
+	if (parts[3] != "-") {
+		board.EnPassantSquare = SquareToNum(parts[3]);
+	}
+
+	board.HalfmoveClock = stoi(parts[4]);
+	board.FullmoveClock = stoi(parts[5]);
+
+	Hashes.push_back(board.CalculateHash());
+}
+
+// Pushing moves ----------------------------------------------------------------------------------
+
+void Position::Push(const Move& move) {
+	assert(move.IsNotNull());
+
+	States.push_back(Board(CurrentState()));
+	Board& board = CurrentState();
+
+	board.HalfmoveClock += 1;
+	board.ApplyMove(move);
+
+	// Increment timers
+	board.Turn = !board.Turn;
+	if (board.Turn == Side::White) board.FullmoveClock += 1;
+
+	Hashes.push_back(board.CalculateHash());
+	assert(States.size() == Hashes.size());
+}
+
+void Position::PushNullMove() {
+	States.push_back(Board(CurrentState()));
+	Board& board = CurrentState();
+	board.Turn = !board.Turn;
+	if (board.EnPassantSquare == -1) {
+		Hashes.push_back(Hashes.back() ^ Zobrist[780]);
+	}
+	else {
+		board.EnPassantSquare = -1;
+		Hashes.push_back(board.CalculateHash());
+	}
+	return;
+}
+
+bool Position::PushUCI(const std::string& str) {
+	const uint8_t sq1 = SquareToNum(str.substr(0, 2));
+	const uint8_t sq2 = SquareToNum(str.substr(2, 2));
+	const char extra = str[4];
+	Move move = Move(sq1, sq2);
+	const uint8_t piece = CurrentState().GetPieceAt(sq1);
+	const uint8_t capturedPiece = CurrentState().GetPieceAt(sq2);
+
+	// Promotions
+	switch (extra) {
+	case 'q': move.flag = MoveFlag::PromotionToQueen; break;
+	case 'r': move.flag = MoveFlag::PromotionToRook; break;
+	case 'b': move.flag = MoveFlag::PromotionToBishop; break;
+	case 'n': move.flag = MoveFlag::PromotionToKnight; break;
+	}
+
+	// Castling
+	if ((piece == Piece::WhiteKing) && (sq1 == 4) && (sq2 == 2)) move = { 4, 0, MoveFlag::LongCastle };
+	else if ((piece == Piece::WhiteKing) && (sq1 == 4) && (sq2 == 6)) move = { 4, 7, MoveFlag::ShortCastle };
+	else if ((piece == Piece::BlackKing) && (sq1 == 60) && (sq2 == 58)) move = { 60, 56, MoveFlag::LongCastle };
+	else if ((piece == Piece::BlackKing) && (sq1 == 60) && (sq2 == 62)) move = { 60, 63, MoveFlag::ShortCastle };
+
+	// En passant possibility
+	if (TypeOfPiece(piece) == PieceType::Pawn) {
+		const uint8_t f1 = sq1 / 8;
+		const uint8_t f2 = sq2 / 8;
+		if (std::abs(f2 - f1) > 1) move.flag = MoveFlag::EnPassantPossible;
+	}
+
+	// En passant performed
+	if (TypeOfPiece(piece) == PieceType::Pawn) {
+		if ((TypeOfPiece(capturedPiece) == 0) && (GetSquareFile(sq1) != GetSquareFile(sq2))) {
+			move.flag = MoveFlag::EnPassantPerformed;
+		}
+	}
+
+	// Generate the list of valid moves
+	MoveList legalMoves{};
+	GenerateMoves(legalMoves, MoveGen::All, Legality::Legal);
+	bool valid = false;
+	for (const auto& m : legalMoves) {
+		if ((m.move.to == move.to) && (m.move.from == move.from) && (m.move.flag == move.flag)) {
+			valid = true;
+			break;
+		}
+	}
+
+	// Make the move if valid
+	if (valid) {
+		Push(move);
+		return true;
+	}
+	else {
+		return false;
+	}
+}
+
+void Position::Pop() {
+	States.pop_back();
+	Hashes.pop_back();
+}
+
+// Generating moves -------------------------------------------------------------------------------
+
+template <bool side, MoveGen moveGen>
+void Position::GenerateKingMoves(MoveList& moves, const int home) const {
+	constexpr uint8_t friendlyPieceColor = (side == Side::White) ? PieceColor::White : PieceColor::Black;
+	constexpr uint8_t opponentPieceColor = (side == Side::White) ? PieceColor::Black : PieceColor::White;
+	uint64_t bits = KingMoveBits[home];
+	while (bits) {
+		const uint8_t l = Popsquare(bits);
+		if (ColorOfPiece(GetPieceAt(l)) == friendlyPieceColor) continue;
+		if ((moveGen == MoveGen::All) || (ColorOfPiece(GetPieceAt(l)) == opponentPieceColor)) moves.pushUnscored(Move(home, l));
+	}
+}
+
+template <bool side, MoveGen moveGen>
+void Position::GenerateKnightMoves(MoveList& moves, const int home) const {
+	constexpr uint8_t friendlyPieceColor = (side == Side::White) ? PieceColor::White : PieceColor::Black;
+	constexpr uint8_t opponentPieceColor = (side == Side::White) ? PieceColor::Black : PieceColor::White;
+	uint64_t bits = KnightMoveBits[home];
+	while (bits) {
+		const uint8_t l = Popsquare(bits);
+		if (ColorOfPiece(GetPieceAt(l)) == friendlyPieceColor) continue;
+		if ((moveGen == MoveGen::All) || (ColorOfPiece(GetPieceAt(l)) == opponentPieceColor)) moves.pushUnscored(Move(home, l));
+	}
+}
+
+template <bool side, int pieceType, MoveGen moveGen>
+void Position::GenerateSlidingMoves(MoveList& moves, const int home, const uint64_t whiteOccupancy, const uint64_t blackOccupancy) const {
+	const uint64_t friendlyOccupance = (side == PieceColor::White) ? whiteOccupancy : blackOccupancy;
+	const uint64_t opponentOccupance = (side == PieceColor::White) ? blackOccupancy : whiteOccupancy;
+	const uint64_t occupancy = whiteOccupancy | blackOccupancy;
+	uint64_t map = 0;
+
+	if constexpr (pieceType == PieceType::Rook) map = GetRookAttacks(home, occupancy) & ~friendlyOccupance;
+	if constexpr (pieceType == PieceType::Bishop) map = GetBishopAttacks(home, occupancy) & ~friendlyOccupance;
+	if constexpr (pieceType == PieceType::Queen) map = GetQueenAttacks(home, occupancy) & ~friendlyOccupance;
+
+	if constexpr (moveGen == MoveGen::Noisy) map &= opponentOccupance;
+	if (map == 0) return;
+
+	while (map != 0) {
+		const int sq = Popsquare(map);
+		moves.pushUnscored(Move(home, sq));
+	}
+}
+
+template <bool side, MoveGen moveGen>
+void Position::GeneratePawnMoves(MoveList& moves, const int home) const {
+
+	const Board& b = CurrentState();
+
+	constexpr int promotionRank = (side == Side::White) ? 7 : 0;
+	constexpr int doublePushRank = (side == Side::White) ? 1 : 6;
+	constexpr int forwardDelta = (side == Side::White) ? 8 : -8;
+	constexpr int doublePushDelta = (side == Side::White) ? 16 : -16;
+	constexpr uint8_t opponentPieceColor = SideToPieceColor(!side);
+
+	// These are like that to avoid bench changing, will be changed to be more intuitive later
+	constexpr int capture1Delta = (side == Side::White) ? 7 : -7;
+	constexpr int capture2Delta = (side == Side::White) ? 9 : -9;
+	constexpr int capture1WrongFile = (side == Side::White) ? 0 : 7;
+	constexpr int capture2WrongFile = (side == Side::White) ? 7 : 0;
+
+	const int file = GetSquareFile(home);
+	const int rank = GetSquareRank(home);
+	int target;
+
+	// 1. Handle moving forward + check promotions
+	target = home + forwardDelta;
+	if (GetPieceAt(target) == Piece::None) {
+		if (GetSquareRank(target) != promotionRank) {
+			if constexpr (moveGen == MoveGen::All) moves.pushUnscored(Move(home, target));
+		}
+		else { // Promote
+			moves.pushUnscored(Move(home, target, MoveFlag::PromotionToQueen));
+			if constexpr (moveGen == MoveGen::All) {
+				moves.pushUnscored(Move(home, target, MoveFlag::PromotionToRook));
+				moves.pushUnscored(Move(home, target, MoveFlag::PromotionToBishop));
+				moves.pushUnscored(Move(home, target, MoveFlag::PromotionToKnight));
+			}
+		}
+	}
+
+	// 2. Handle captures + check promotions + check en passant
+	constexpr std::array<std::pair<int, int>, 2> captureDetails =
+	{ std::pair{capture1Delta, capture1WrongFile}, std::pair{capture2Delta, capture2WrongFile} };
+
+	for (const auto& [delta, wrongFile] : captureDetails) {
+		target = home + delta;
+
+		if ((file != wrongFile) && ((ColorOfPiece(GetPieceAt(target)) == opponentPieceColor) || (target == b.EnPassantSquare))) {
+			if (GetSquareRank(target) != promotionRank) {
+				const uint8_t moveFlag = (target == b.EnPassantSquare) ? MoveFlag::EnPassantPerformed : MoveFlag::None;
+				moves.pushUnscored(Move(home, target, moveFlag));
+			}
+			else { // Promote
+				moves.pushUnscored(Move(home, target, MoveFlag::PromotionToQueen));
+				if constexpr (moveGen == MoveGen::All) {
+					moves.pushUnscored(Move(home, target, MoveFlag::PromotionToRook));
+					moves.pushUnscored(Move(home, target, MoveFlag::PromotionToBishop));
+					moves.pushUnscored(Move(home, target, MoveFlag::PromotionToKnight));
+				}
+			}
+		}
+	}
+
+	// 3. Handle double pushes
+	if (rank == doublePushRank) {
+		const bool free1 = GetPieceAt(home + forwardDelta) == Piece::None;
+		const bool free2 = GetPieceAt(home + doublePushDelta) == Piece::None;
+		if (free1 && free2) {
+			if constexpr (moveGen == MoveGen::All) moves.pushUnscored(Move(home, home + doublePushDelta, MoveFlag::EnPassantPossible));
+		}
+	}
+
+}
+
+template <bool side>
+void Position::GenerateCastlingMoves(MoveList& moves) const {
+
+	using namespace Squares;
+	const Board& b = CurrentState();
+
+	constexpr auto shortEmpty = (side == Side::White) ? std::array{ F1, G1 } : std::array{ F8, G8 };
+	constexpr auto shortSafe = (side == Side::White) ? std::array{ E1, F1, G1 } : std::array{ E8, F8, G8 };
+	constexpr auto longEmpty = (side == Side::White) ? std::array{ B1, C1, D1 } : std::array{ B8, C8, D8 };
+	constexpr auto longSafe = (side == Side::White) ? std::array{ C1, D1, E1 } : std::array{ C8, D8, E8 };
+	constexpr int from = (side == Side::White) ? E1 : E8;
+	constexpr int shortRook = (side == Side::White) ? H1 : H8;
+	constexpr int longRook = (side == Side::White) ? A1 : A8;
+
+	const bool rightToShortCastle = (side == Side::White) ? b.WhiteRightToShortCastle : b.BlackRightToShortCastle;
+	const bool rightToLongCastle = (side == Side::White) ? b.WhiteRightToLongCastle : b.BlackRightToLongCastle;
+
+	if (rightToShortCastle) {
+		const bool empty = std::all_of(shortEmpty.begin(), shortEmpty.end(), [&](const int sq) {
+			return GetPieceAt(sq) == Piece::None;
+			});
+		if (empty) {
+			const bool safe = std::all_of(shortSafe.begin(), shortSafe.end(), [&](const int sq) {
+				return !IsSquareAttacked<!side>(sq);
+				});
+			if (safe) moves.pushUnscored(Move(from, shortRook, MoveFlag::ShortCastle));
+		}
+	}
+	if (rightToLongCastle) {
+		const bool empty = std::all_of(longEmpty.begin(), longEmpty.end(), [&](const int sq) {
+			return GetPieceAt(sq) == Piece::None;
+			});
+		if (empty) {
+			const bool safe = std::all_of(longSafe.begin(), longSafe.end(), [&](const int sq) {
+				return !IsSquareAttacked<!side>(sq);
+				});
+			if (safe) moves.pushUnscored(Move(from, longRook, MoveFlag::LongCastle));
+		}
+	}
+}
+
+void Position::GenerateMoves(MoveList& moves, const MoveGen moveGen, const Legality legality) const {
+
+	const Board& board = CurrentState();
+
+	if (legality == Legality::Pseudolegal) {
+		if (moveGen == MoveGen::All) {
+			if (board.Turn == Side::White) GeneratePseudolegalMoves<Side::White, MoveGen::All>(moves);
+			else GeneratePseudolegalMoves<Side::Black, MoveGen::All>(moves);
+		}
+		else if (moveGen == MoveGen::Noisy) {
+			if (board.Turn == Side::White) GeneratePseudolegalMoves<Side::White, MoveGen::Noisy>(moves);
+			else GeneratePseudolegalMoves<Side::Black, MoveGen::Noisy>(moves);
+		}
+	}
+	else {
+		MoveList legalMoves{};
+		if (moveGen == MoveGen::All) {
+			if (board.Turn == Side::White) GeneratePseudolegalMoves<Side::White, MoveGen::All>(legalMoves);
+			else GeneratePseudolegalMoves<Side::Black, MoveGen::All>(legalMoves);
+		}
+		else if (moveGen == MoveGen::Noisy) {
+			if (board.Turn == Side::White) GeneratePseudolegalMoves<Side::White, MoveGen::Noisy>(legalMoves);
+			else GeneratePseudolegalMoves<Side::Black, MoveGen::Noisy>(legalMoves);
+		}
+		for (const auto& m : legalMoves) {
+			if (IsLegalMove(m.move)) moves.pushUnscored(m.move);
+		}
+	}
+}
+
+template <bool side, MoveGen moveGen>
+void Position::GeneratePseudolegalMoves(MoveList& moves) const {
+	const uint64_t whiteOccupancy = GetOccupancy(Side::White);
+	const uint64_t blackOccupancy = GetOccupancy(Side::Black);
+	uint64_t friendlyOccupancy = (Turn() == Side::White) ? whiteOccupancy : blackOccupancy;
+
+	while (friendlyOccupancy != 0) {
+		const int sq = Popsquare(friendlyOccupancy);
+		const int type = TypeOfPiece(GetPieceAt(sq));
+
+		switch (type) {
+		case PieceType::Pawn:
+			GeneratePawnMoves<side, moveGen>(moves, sq);
+			break;
+		case PieceType::Knight:
+			GenerateKnightMoves<side, moveGen>(moves, sq);
+			break;
+		case PieceType::Bishop:
+			GenerateSlidingMoves<side, PieceType::Bishop, moveGen>(moves, sq, whiteOccupancy, blackOccupancy);
+			break;
+		case PieceType::Rook:
+			GenerateSlidingMoves<side, PieceType::Rook, moveGen>(moves, sq, whiteOccupancy, blackOccupancy);
+			break;
+		case PieceType::Queen:
+			GenerateSlidingMoves<side, PieceType::Queen, moveGen>(moves, sq, whiteOccupancy, blackOccupancy);
+			break;
+		case PieceType::King:
+			GenerateKingMoves<side, moveGen>(moves, sq);
+			if constexpr (moveGen == MoveGen::All) GenerateCastlingMoves<side>(moves);
+			break;
+
+		}
+	}
+}
+
+// Threats and move legality ----------------------------------------------------------------------
+
+template <bool attackingSide>
+uint64_t Position::CalculateAttackedSquaresTemplated() const {
+
+	uint64_t map = 0;
+	const Board& b = CurrentState();
+
+	// Pawn attacks
+	map = (attackingSide == Side::White) ? GetPawnAttacks<Side::White>() : GetPawnAttacks<Side::Black>();
+
+	// Knight attacks
+	uint64_t knightBits = (attackingSide == Side::White) ? b.WhiteKnightBits : b.BlackKnightBits;
+	while (knightBits) {
+		const uint8_t sq = Popsquare(knightBits);
+		map |= GenerateKnightAttacks(sq);
+	}
+
+	// King attacks
+	uint8_t kingSquare = 63 - Lzcount((attackingSide == Side::White) ? b.WhiteKingBits : b.BlackKingBits);
+	map |= KingMoveBits[kingSquare];
+
+	// Sliding pieces
+	// 'parallel' comes from being parallel to the axes, better name suggestions welcome
+	uint64_t occ = GetOccupancy();
+	uint64_t parallelSliders = (attackingSide == Side::White) ? (b.WhiteRookBits | b.WhiteQueenBits) : (b.BlackRookBits | b.BlackQueenBits);
+	uint64_t diagonalSliders = (attackingSide == Side::White) ? (b.WhiteBishopBits | b.WhiteQueenBits) : (b.BlackBishopBits | b.BlackQueenBits);
+
+	while (parallelSliders) {
+		const uint8_t sq = Popsquare(parallelSliders);
+		map |= GetRookAttacks(sq, occ);
+	}
+	while (diagonalSliders) {
+		const uint8_t sq = Popsquare(diagonalSliders);
+		map |= GetBishopAttacks(sq, occ);
+	}
+
+	return map;
+}
+
+uint64_t Position::CalculateAttackedSquares(const bool attackingSide) const {
+	return (attackingSide == Side::White) ? CalculateAttackedSquaresTemplated<Side::White>() : CalculateAttackedSquaresTemplated<Side::Black>();
+}
+
+uint64_t Position::GetAttackersOfSquare(const uint8_t square, const uint64_t occupied) const {
+	// if not being used for SEE: occupied = GetOccupancy();
+
+	// Generate attackers setwise
+	// Taking advantage of the fact that for non-pawns, if X attacks Y, then Y attacks X
+	const Board& b = States.back();
+	const uint64_t pawnAttackers = (WhitePawnAttacks[square] & b.BlackPawnBits) | (BlackPawnAttacks[square] & b.WhitePawnBits);
+	const uint64_t knightAttackers = KnightMoveBits[square] & (b.WhiteKnightBits | b.BlackKnightBits);
+	const uint64_t bishopAttackers = GetBishopAttacks(square, occupied) & (b.WhiteBishopBits | b.BlackBishopBits | b.WhiteQueenBits | b.BlackQueenBits);
+	const uint64_t rookAttackers = GetRookAttacks(square, occupied) & (b.WhiteRookBits | b.BlackRookBits | b.WhiteQueenBits | b.BlackQueenBits);
+	const uint64_t kingAttackers = KingMoveBits[square] & (b.WhiteKingBits | b.BlackKingBits);
+	return pawnAttackers | knightAttackers | bishopAttackers | rookAttackers | kingAttackers;
+}
+
+// This function assumes that the move is at least pseudolegal
+// This is terrible currently, but it was pain to get right, and I don't want to touch it with a 10 ft pole
+bool Position::IsLegalMove(const Move& m) const {
+	
+	//if (m.IsNull()) cout << "#" << endl;
+
+	if (m.IsCastling()) return true; // Castling is guaranteed to be legal from movegen
+
+	const Board& board = CurrentState();
+	const uint8_t movedPiece = GetPieceAt(m.from);
+
+	if (TypeOfPiece(movedPiece) == PieceType::King) {
+		// Destination square must not be attacked by the opponent
+		const uint8_t kingSq = (board.Turn == Side::White) ? LsbSquare(board.WhiteKingBits) : LsbSquare(board.BlackKingBits);
+		const uint64_t occupancy = GetOccupancy() ^ SquareBit(kingSq);
+		return (board.Turn == Side::White) ? !IsSquareAttacked2(Side::Black, m.to, occupancy) : !IsSquareAttacked2(Side::White, m.to, occupancy);
+	}
+
+	const uint8_t capturedPiece = GetPieceAt(m.to);
+	const uint8_t kingSq = (board.Turn == Side::White) ? LsbSquare(board.WhiteKingBits) : LsbSquare(board.BlackKingBits);
+	const uint64_t occupancy = GetOccupancy();
+
+	if (m.flag == MoveFlag::EnPassantPerformed) {
+		// After the en passant start rays to see if the king is attacked by an appropiate sliding piece
+		// TODO: Checking for only rook attacks is enough, I think?
+		const uint8_t epVictimSq = (board.Turn == Side::White) ? board.EnPassantSquare - 8 : board.EnPassantSquare + 8;
+		const uint64_t parallelSliders = (board.Turn == Side::White) ? (board.BlackRookBits | board.BlackQueenBits) : (board.WhiteRookBits | board.WhiteQueenBits);
+		const uint64_t diagonalSliders = (board.Turn == Side::White) ? (board.BlackBishopBits | board.BlackQueenBits) : (board.WhiteBishopBits | board.WhiteQueenBits);
+		const uint64_t approxOccupancy = occupancy ^ SquareBit(m.from) ^ SquareBit(epVictimSq) | SquareBit(m.to);
+		return !(GetRookAttacks(kingSq, approxOccupancy) & parallelSliders) && !(GetBishopAttacks(kingSq, approxOccupancy) & diagonalSliders);
+	}
+
+	// Regular non-king moves
+
+	const uint64_t checking = AttackersOfSquare(!Turn(), kingSq);
+	if (Popcount(checking) > 1) return false; // double checks can only be evaded by a king move
+
+	if (!checking) {
+		const uint64_t parallelSliders = ((board.Turn == Side::White) ? (board.BlackRookBits | board.BlackQueenBits) : (board.WhiteRookBits | board.WhiteQueenBits)) & ~SquareBit(m.to);
+		const uint64_t diagonalSliders = ((board.Turn == Side::White) ? (board.BlackBishopBits | board.BlackQueenBits) : (board.WhiteBishopBits | board.WhiteQueenBits)) & ~SquareBit(m.to);
+		const uint64_t approxOccupancy = (occupancy ^ SquareBit(kingSq) ^ SquareBit(m.from)) | SquareBit(m.to);
+		return !(GetRookAttacks(kingSq, approxOccupancy) & parallelSliders) && !(GetBishopAttacks(kingSq, approxOccupancy) & diagonalSliders);
+	}
+	else {
+		if (m.to == LsbSquare(checking)) {
+			const uint64_t parallelSliders = ((board.Turn == Side::White) ? (board.BlackRookBits | board.BlackQueenBits) : (board.WhiteRookBits | board.WhiteQueenBits)) & ~SquareBit(m.to);
+			const uint64_t diagonalSliders = ((board.Turn == Side::White) ? (board.BlackBishopBits | board.BlackQueenBits) : (board.WhiteBishopBits | board.WhiteQueenBits)) & ~SquareBit(m.to);
+			const uint64_t approxOccupancy = (occupancy ^ SquareBit(kingSq) ^ SquareBit(m.from)) | SquareBit(m.to);
+			const uint64_t pin1 = GetRookAttacks(kingSq, approxOccupancy) & parallelSliders;
+			const uint64_t pin2 = GetBishopAttacks(kingSq, approxOccupancy) & diagonalSliders;
+			const uint64_t pins = pin1 | pin2;
+			return !pins;
+		}
+		else {
+			if (checking & (board.WhiteKnightBits | board.BlackKnightBits | board.WhiteKingBits | board.BlackKingBits | board.WhitePawnBits | board.BlackPawnBits)) return false;
+			const uint64_t parallelSliders = ((board.Turn == Side::White) ? (board.BlackRookBits | board.BlackQueenBits) : (board.WhiteRookBits | board.WhiteQueenBits)) & ~SquareBit(m.to);
+			const uint64_t diagonalSliders = ((board.Turn == Side::White) ? (board.BlackBishopBits | board.BlackQueenBits) : (board.WhiteBishopBits | board.WhiteQueenBits)) & ~SquareBit(m.to);
+			const uint64_t approxOccupancy = (occupancy ^ SquareBit(kingSq) ^ SquareBit(m.from)) | SquareBit(m.to);
+			const uint64_t pin1 = GetRookAttacks(kingSq, approxOccupancy) & parallelSliders;
+			const uint64_t pin2 = GetBishopAttacks(kingSq, approxOccupancy) & diagonalSliders;
+			const uint64_t pins = pin1 | pin2;
+			return !pins;
+		}
+	}
+
+}
+
+
+
+template <bool attackingSide>
+bool Position::IsSquareAttacked(const uint8_t square) const {
+	const uint64_t occupancy = GetOccupancy();
+	const Board& b = CurrentState();
+
+	if constexpr (attackingSide == Side::White) {
+		// Attacked by a knight?
+		if (KnightMoveBits[square] & b.WhiteKnightBits) return true;
+		// Attacked by a king?
+		if (KingMoveBits[square] & b.WhiteKingBits) return true;
+		// Attacked by a pawn?
+		if (SquareBit(square) & ((b.WhitePawnBits & ~File[0]) << 7)) return true;
+		if (SquareBit(square) & ((b.WhitePawnBits & ~File[7]) << 9)) return true;
+		// Attacked by a sliding piece?
+		if (GetRookAttacks(square, occupancy) & (b.WhiteRookBits | b.WhiteQueenBits)) return true;
+		if (GetBishopAttacks(square, occupancy) & (b.WhiteBishopBits | b.WhiteQueenBits)) return true;
+		// Okay
+		return false;
+	}
+	else {
+		// Attacked by a knight?
+		if (KnightMoveBits[square] & b.BlackKnightBits) return true;
+		// Attacked by a king?
+		if (KingMoveBits[square] & b.BlackKingBits) return true;
+		// Attacked by a pawn?
+		if (SquareBit(square) & ((b.BlackPawnBits & ~File[0]) >> 9)) return true;
+		if (SquareBit(square) & ((b.BlackPawnBits & ~File[7]) >> 7)) return true;
+		// Attacked by a sliding piece?
+		if (GetRookAttacks(square, occupancy) & (b.BlackRookBits | b.BlackQueenBits)) return true;
+		if (GetBishopAttacks(square, occupancy) & (b.BlackBishopBits | b.BlackQueenBits)) return true;
+		// Okay
+		return false;
+	}
+}
+
+// will be simplified somehow
+bool Position::IsSquareAttacked2(const bool attackingSide, const uint8_t square, const uint64_t occupancy) const {
+	const Board& b = CurrentState();
+
+	if (attackingSide == Side::White) {
+		// Attacked by a knight?
+		if (KnightMoveBits[square] & b.WhiteKnightBits) return true;
+		// Attacked by a king?
+		if (KingMoveBits[square] & b.WhiteKingBits) return true;
+		// Attacked by a pawn?
+		if (SquareBit(square) & ((b.WhitePawnBits & ~File[0]) << 7)) return true;
+		if (SquareBit(square) & ((b.WhitePawnBits & ~File[7]) << 9)) return true;
+		// Attacked by a sliding piece?
+		if (GetRookAttacks(square, occupancy) & (b.WhiteRookBits | b.WhiteQueenBits)) return true;
+		if (GetBishopAttacks(square, occupancy) & (b.WhiteBishopBits | b.WhiteQueenBits)) return true;
+		// Okay
+		return false;
+	}
+	else {
+		// Attacked by a knight?
+		if (KnightMoveBits[square] & b.BlackKnightBits) return true;
+		// Attacked by a king?
+		if (KingMoveBits[square] & b.BlackKingBits) return true;
+		// Attacked by a pawn?
+		if (SquareBit(square) & ((b.BlackPawnBits & ~File[0]) >> 9)) return true;
+		if (SquareBit(square) & ((b.BlackPawnBits & ~File[7]) >> 7)) return true;
+		// Attacked by a sliding piece?
+		if (GetRookAttacks(square, occupancy) & (b.BlackRookBits | b.BlackQueenBits)) return true;
+		if (GetBishopAttacks(square, occupancy) & (b.BlackBishopBits | b.BlackQueenBits)) return true;
+		// Okay
+		return false;
+	}
+}
+
+uint64_t Position::AttackersOfSquare(const bool attackingSide, const uint8_t square) const {
+	const uint64_t occupancy = GetOccupancy();
+	const Board& b = CurrentState();
+	uint64_t attackers = 0;
+
+	if (attackingSide == Side::White) {
+		attackers |= (KnightMoveBits[square] & b.WhiteKnightBits);
+		attackers |= (KingMoveBits[square] & b.WhiteKingBits);
+		attackers |= ((SquareBit(square) & ~File[0]) >> 9) & b.WhitePawnBits;
+		attackers |= ((SquareBit(square) & ~File[7]) >> 7) & b.WhitePawnBits;
+		attackers |= (GetRookAttacks(square, occupancy) & (b.WhiteRookBits | b.WhiteQueenBits));
+		attackers |= (GetBishopAttacks(square, occupancy) & (b.WhiteBishopBits | b.WhiteQueenBits));
+	}
+	else {
+		attackers |= (KnightMoveBits[square] & b.BlackKnightBits);
+		attackers |= (KingMoveBits[square] & b.BlackKingBits);
+		attackers |= ((SquareBit(square) & ~File[7]) << 9) & b.BlackPawnBits;
+		attackers |= ((SquareBit(square) & ~File[0]) << 7) & b.BlackPawnBits;
+		attackers |= (GetRookAttacks(square, occupancy) & (b.BlackRookBits | b.BlackQueenBits));
+		attackers |= (GetBishopAttacks(square, occupancy) & (b.BlackBishopBits | b.BlackQueenBits));
+	}
+	return attackers;
+}
+
+// Getting information ----------------------------------------------------------------------------
+
+bool Position::IsDrawn(const bool threefold) const {
+	const Board& b = CurrentState();
+
+	// 1. Fifty moves without progress
+	if (b.HalfmoveClock >= 100) return true;
+
+	// 2. Threefold repetitions
+	const uint64_t hash = Hash();
+	const int length = Hashes.size();
+	const int threshold = threefold ? 3 : 2;
+	int repeated = 0;
+
+	for (int i = length - 1; i >= std::max(0, length - b.HalfmoveClock - 2); i -= 2) {
+		if (Hashes[i] == hash) {
+			repeated += 1;
+			if (repeated >= threshold) return true;
+		}
+	}
+
+	// 3. Insufficient material check
+	// - has pawns or major pieces -> sufficient
+	if (b.WhitePawnBits | b.BlackPawnBits) return false;
+	if (b.WhiteRookBits | b.BlackRookBits | b.WhiteQueenBits | b.BlackQueenBits) return false;
+	// - less than 4 with minor pieces is a draw, more than 4 is not
+	const int pieceCount = Popcount(GetOccupancy());
+	if (pieceCount > 4) return false;
+	if (pieceCount < 4) return true;
+	// - for exactly 4 pieces, check for same-color KBvKB
+	if (Popcount(b.WhiteBishopBits & LightSquares) == 1 && Popcount(b.BlackBishopBits & LightSquares) == 1) return true;
+	if (Popcount(b.WhiteBishopBits & DarkSquares) == 1 && Popcount(b.BlackBishopBits & DarkSquares) == 1) return true;
+	return false;
+}
+
+bool Position::IsMoveQuiet(const Move& move) const {
+	if (move.IsCastling()) return true;
+	const uint8_t movedPiece = GetPieceAt(move.from);
+	const uint8_t targetPiece = GetPieceAt(move.to);
+	if (targetPiece != Piece::None) return false;
+	if (move.flag == MoveFlag::PromotionToQueen) return false;
+	if (move.flag == MoveFlag::EnPassantPerformed) return false;
+	return true;
+}
+
+std::string Position::GetFEN() const {
+	const Board& b = CurrentState();
+	std::string result{};
+	for (int r = 7; r >= 0; r--) {
+		int spaces = 0;
+		for (int f = 0; f < 8; f++) {
+			int piece = GetPieceAt(Square(r, f));
+			if (piece == 0) {
+				spaces += 1;
+			}
+			else {
+				if (spaces != 0) result += std::to_string(spaces);
+				result += PieceChars[piece];
+				spaces = 0;
+			}
+		}
+		if (spaces != 0) result += std::to_string(spaces);
+		if (r != 0) result += '/';
+	}
+
+	result += (Turn() == Side::White) ? " w " : " b ";
+
+	bool castlingPossible = false;
+	if (b.WhiteRightToShortCastle) { result += 'K'; castlingPossible = true; }
+	if (b.WhiteRightToLongCastle) { result += 'Q'; castlingPossible = true; }
+	if (b.BlackRightToShortCastle) { result += 'k'; castlingPossible = true; }
+	if (b.BlackRightToLongCastle) { result += 'q'; castlingPossible = true; }
+	if (!castlingPossible) result += '-';
+	result += ' ';
+
+	bool enPassantPossible = false;
+	if ((b.EnPassantSquare != -1) && (b.Turn == Side::White)) {
+		const bool fromRight = (((b.WhitePawnBits & ~File[0]) << 7) & SquareBit(b.EnPassantSquare));
+		const bool fromLeft = (((b.WhitePawnBits & ~File[7]) << 9) & SquareBit(b.EnPassantSquare));
+		if (fromLeft || fromRight) enPassantPossible = true;
+	}
+	if ((b.EnPassantSquare != -1) && (b.Turn == Side::Black)) {
+		const bool fromRight = (((b.BlackPawnBits & ~File[0]) >> 9) & SquareBit(b.EnPassantSquare));
+		const bool fromLeft = (((b.BlackPawnBits & ~File[7]) >> 7) & SquareBit(b.EnPassantSquare));
+		if (fromLeft || fromRight) enPassantPossible = true;
+	}
+	if (enPassantPossible) result += SquareStrings[b.EnPassantSquare];
+	else result += '-';
+
+	result += ' ' + std::to_string(b.HalfmoveClock) + ' ' + std::to_string(b.FullmoveClock);
+	return result;
+}
+
+GameState Position::GetGameState() const {
+	// Check checkmates & stalemates
+	MoveList moves{};
+	GenerateMoves(moves, MoveGen::All, Legality::Legal);
+	if (moves.size() == 0) {
+		if (IsInCheck()) {
+			if (Turn() == Side::Black) return GameState::WhiteVictory;
+			else return GameState::BlackVictory;
+		}
+		else {
+			return GameState::Draw; // Stalemate
+		}
+	}
+
+	// Check other types of draws
+	if (IsDrawn(true)) return GameState::Draw;
+	else return GameState::Playing;
+}

--- a/Renegade/Position.h
+++ b/Renegade/Position.h
@@ -1,0 +1,132 @@
+#pragma once
+#include "Board.h"
+#include "Move.h"
+#include "Utils.h"
+
+// Magic lookup tables
+uint64_t GetBishopAttacks(const uint8_t square, const uint64_t occupancy);
+uint64_t GetRookAttacks(const uint8_t square, const uint64_t occupancy);
+uint64_t GetQueenAttacks(const uint8_t square, const uint64_t occupancy);
+
+class Position
+{
+public:
+
+	Position(const std::string& fen);
+	Position() : Position(FEN::StartPos) {};
+
+	void Push(const Move& move);
+	void PushNullMove();
+	bool PushUCI(const std::string& ucistr);
+	void Pop();
+
+	void GenerateMoves(MoveList& moves, const MoveGen moveGen, const Legality legality) const;
+	bool IsDrawn(const bool threefold) const;
+
+	bool IsLegalMove(const Move& m) const;
+	bool IsMoveQuiet(const Move& move) const;
+
+	inline Board& CurrentState() {
+		return States.back();
+	}
+
+	inline const Board& CurrentState() const {
+		return States.back();
+	}
+
+	inline uint64_t GetOccupancy() const {
+		const Board& b = States.back();
+		return b.WhitePawnBits | b.WhiteKnightBits | b.WhiteBishopBits | b.WhiteRookBits | b.WhiteQueenBits | b.WhiteKingBits
+			| b.BlackPawnBits | b.BlackKnightBits | b.BlackBishopBits | b.BlackRookBits | b.BlackQueenBits | b.BlackKingBits;
+	}
+
+	inline uint64_t GetOccupancy(const bool side) const {
+		const Board& b = States.back();
+		if (side == Side::White) return b.WhitePawnBits | b.WhiteKnightBits | b.WhiteBishopBits | b.WhiteRookBits | b.WhiteQueenBits | b.WhiteKingBits;
+		else return b.BlackPawnBits | b.BlackKnightBits | b.BlackBishopBits | b.BlackRookBits | b.BlackQueenBits | b.BlackKingBits;
+	}
+
+	inline uint8_t GetPieceAt(const uint8_t square) const {
+		return States.back().GetPieceAt(square);
+	}
+
+	inline bool Turn() const {
+		return States.back().Turn;
+	}
+
+	inline bool IsInCheck() const {
+		if (Turn() == Side::White) return IsSquareAttacked<Side::Black>(LsbSquare(WhiteKingBits()));
+		else return IsSquareAttacked<Side::White>(LsbSquare(BlackKingBits()));
+	}
+
+	inline uint64_t Hash() const {
+		return Hashes.back();
+	}
+
+	inline int GetPlys() const {
+		const Board& b = States.back();
+		return (b.FullmoveClock - 1) * 2 + (b.Turn == Side::White ? 0 : 1);
+	}
+
+	inline bool HasNonPawnMaterial() const {
+		const Board& b = States.back();
+		const int friendlyPieces = Popcount(GetOccupancy(b.Turn));
+		const int friendlyPawns = (b.Turn == Side::White) ? Popcount(b.WhitePawnBits) : Popcount(b.BlackPawnBits);
+		return (friendlyPieces - friendlyPawns) > 1;
+	}
+
+	template <bool side>
+	inline uint64_t GetPawnAttacks() const {
+		const Board& b = CurrentState();
+		if constexpr (side == Side::White) return ((b.WhitePawnBits & ~File[0]) << 7) | ((b.WhitePawnBits & ~File[7]) << 9);
+		else return ((b.BlackPawnBits & ~File[0]) >> 9) | ((b.BlackPawnBits & ~File[7]) >> 7);
+	}
+
+	inline uint64_t GenerateKnightAttacks(const int from) const {
+		return KnightMoveBits[from];
+	}
+
+	inline uint64_t GenerateKingAttacks(const int from) const {
+		return KingMoveBits[from];
+	}
+
+	template<bool attackingSide> bool IsSquareAttacked(const uint8_t square) const;
+	uint64_t AttackersOfSquare(const bool attackingSide, const uint8_t square) const;
+	bool IsSquareAttacked2(const bool attackingSide, const uint8_t square, const uint64_t occupancy) const;
+
+
+	inline uint64_t WhitePawnBits() const { return States.back().WhitePawnBits; }
+	inline uint64_t WhiteKnightBits() const { return States.back().WhiteKnightBits; }
+	inline uint64_t WhiteBishopBits() const { return States.back().WhiteBishopBits; }
+	inline uint64_t WhiteRookBits() const { return States.back().WhiteRookBits; }
+	inline uint64_t WhiteQueenBits() const { return States.back().WhiteQueenBits; }
+	inline uint64_t WhiteKingBits() const { return States.back().WhiteKingBits; }
+	inline uint64_t BlackPawnBits() const { return States.back().BlackPawnBits; }
+	inline uint64_t BlackKnightBits() const { return States.back().BlackKnightBits; }
+	inline uint64_t BlackBishopBits() const { return States.back().BlackBishopBits; }
+	inline uint64_t BlackRookBits() const { return States.back().BlackRookBits; }
+	inline uint64_t BlackQueenBits() const { return States.back().BlackQueenBits; }
+	inline uint64_t BlackKingBits() const { return States.back().BlackKingBits; }
+
+	uint64_t CalculateAttackedSquares(const bool attackingSide) const;
+	template <bool attackingSide> uint64_t CalculateAttackedSquaresTemplated() const;
+	uint64_t GetAttackersOfSquare(const uint8_t square, const uint64_t occupied) const;
+	std::string GetFEN() const;
+	GameState GetGameState() const;
+
+	std::vector<Board> States{};
+	std::vector<uint64_t> Hashes{};
+	CastlingConfiguration CastlingConfig{};
+
+private:
+
+	template <bool side, MoveGen moveGen> void GeneratePseudolegalMoves(MoveList& moves) const;
+	template <bool side, MoveGen moveGen> void GenerateKnightMoves(MoveList& moves, const int home) const;
+	template <bool side, MoveGen moveGen> void GenerateKingMoves(MoveList& moves, const int home) const;
+	template <bool side, MoveGen moveGen> void GeneratePawnMoves(MoveList& moves, const int home) const;
+	template <bool side> void GenerateCastlingMoves(MoveList& moves) const;
+	template <bool side, int pieceType, MoveGen moveGen> void GenerateSlidingMoves(MoveList& moves, const int home, const uint64_t whiteOccupancy, const uint64_t blackOccupancy) const;
+
+
+};
+

--- a/Renegade/Renegade.vcxproj
+++ b/Renegade/Renegade.vcxproj
@@ -147,13 +147,15 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="Board.cpp" />
+    <ClCompile Include="Board2.cpp" />
+    <ClCompile Include="BoardState.cpp" />
     <ClCompile Include="Datagen.cpp" />
     <ClCompile Include="Engine.cpp" />
     <ClCompile Include="Evaluation.cpp" />
     <ClCompile Include="Magics.cpp" />
     <ClCompile Include="Heuristics.cpp" />
     <ClCompile Include="Neurals.cpp" />
+    <ClCompile Include="Position.cpp" />
     <ClCompile Include="Renegade.cpp" />
     <ClCompile Include="Reporting.cpp" />
     <ClCompile Include="Search.cpp" />
@@ -161,7 +163,8 @@
     <ClCompile Include="Utils.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Board.h" />
+    <ClInclude Include="Board2.h" />
+    <ClInclude Include="BoardState.h" />
     <ClInclude Include="Datagen.h" />
     <ClInclude Include="Engine.h" />
     <ClInclude Include="Evaluation.h" />
@@ -169,6 +172,7 @@
     <ClInclude Include="Move.h" />
     <ClInclude Include="Heuristics.h" />
     <ClInclude Include="Neurals.h" />
+    <ClInclude Include="Position.h" />
     <ClInclude Include="Reporting.h" />
     <ClInclude Include="Search.h" />
     <ClInclude Include="Settings.h" />

--- a/Renegade/Renegade.vcxproj
+++ b/Renegade/Renegade.vcxproj
@@ -147,8 +147,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="Board2.cpp" />
-    <ClCompile Include="BoardState.cpp" />
+    <ClCompile Include="Board.cpp" />
     <ClCompile Include="Datagen.cpp" />
     <ClCompile Include="Engine.cpp" />
     <ClCompile Include="Evaluation.cpp" />
@@ -163,8 +162,7 @@
     <ClCompile Include="Utils.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Board2.h" />
-    <ClInclude Include="BoardState.h" />
+    <ClInclude Include="Board.h" />
     <ClInclude Include="Datagen.h" />
     <ClInclude Include="Engine.h" />
     <ClInclude Include="Evaluation.h" />

--- a/Renegade/Renegade.vcxproj.filters
+++ b/Renegade/Renegade.vcxproj.filters
@@ -18,9 +18,6 @@
     <ClCompile Include="Renegade.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Board2.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="Engine.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -48,7 +45,13 @@
     <ClCompile Include="Position.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="BoardState.cpp">
+    <ClCompile Include="Board.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Datagen.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Evaluation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -57,9 +60,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Engine.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Board2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Heuristics.h">
@@ -86,7 +86,13 @@
     <ClInclude Include="Position.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="BoardState.h">
+    <ClInclude Include="Board.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Datagen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Evaluation.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Renegade/Renegade.vcxproj.filters
+++ b/Renegade/Renegade.vcxproj.filters
@@ -18,7 +18,7 @@
     <ClCompile Include="Renegade.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Board.cpp">
+    <ClCompile Include="Board2.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Engine.cpp">
@@ -39,16 +39,16 @@
     <ClCompile Include="Utils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Evaluation.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="Neurals.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Datagen.cpp">
+    <ClCompile Include="Settings.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Settings.cpp">
+    <ClCompile Include="Position.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="BoardState.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -59,7 +59,7 @@
     <ClInclude Include="Engine.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Board.h">
+    <ClInclude Include="Board2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Heuristics.h">
@@ -77,16 +77,16 @@
     <ClInclude Include="Utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Evaluation.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="Neurals.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Datagen.h">
+    <ClInclude Include="Settings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Settings.h">
+    <ClInclude Include="Position.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="BoardState.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Renegade/Reporting.h
+++ b/Renegade/Reporting.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Board.h"
 #include "Move.h"
 #include "Settings.h"
 

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "Board.h"
-#include "Evaluation.h"
 #include "Heuristics.h"
 #include "Neurals.h"
+#include "Position.h"
 #include "Reporting.h"
 #include "Utils.h"
 #include <atomic>
@@ -25,29 +24,29 @@ public:
 	Search();
 	void ResetState(const bool clearTT);
 
-	void Perft(Board& board, const int depth, const PerftType type) const;
-	Results SearchMoves(Board board, const SearchParams params, const bool display);
-	bool StaticExchangeEval(const Board& board, const Move& move, const int threshold) const;
+	void Perft(Position& position, const int depth, const PerftType type) const;
+	Results SearchMoves(Position& position, const SearchParams params, const bool display);
+	bool StaticExchangeEval(const Position& position, const Move& move, const int threshold) const;
 
 	std::atomic<bool> Aborting = true;
 	bool DatagenMode = false;
 	Heuristics Heuristics;
 
 private:
-	int SearchRecursive(Board& board, int depth, const int level, int alpha, int beta, const bool canNullMove);
-	int SearchQuiescence(Board& board, const int level, int alpha, int beta);
-	int Evaluate(const Board& board, const int level);
-	uint64_t PerftRecursive(Board& board, const int depth, const int originalDepth, const PerftType type) const;
+	int SearchRecursive(Position& position, int depth, const int level, int alpha, int beta, const bool canNullMove);
+	int SearchQuiescence(Position& position, const int level, int alpha, int beta);
+	int Evaluate(const Position& position, const int level);
+	uint64_t PerftRecursive(Position& position, const int depth, const int originalDepth, const PerftType type) const;
 	SearchConstraints CalculateConstraints(const SearchParams params, const bool turn) const;
 	bool ShouldAbort();
-	int DrawEvaluation();
+	int DrawEvaluation() const;
 	void ResetStatistics();
 
-	void OrderMoves(const Board& board, MoveList& ml, const int level, const Move& ttMove, const uint64_t opponentAttacks);
-	void OrderMovesQ(const Board& board, MoveList& ml, const int level);
+	void OrderMoves(const Position& position, MoveList& ml, const int level, const Move& ttMove, const uint64_t opponentAttacks);
+	void OrderMovesQ(const Position& position, MoveList& ml, const int level);
 
 	// NNUE
-	void SetupAccumulators(const Board& board);
+	void SetupAccumulators(const Position& position);
 	void UpdateAccumulators(const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece, const int level);
 
 	std::unique_ptr<std::array<AccumulatorRepresentation, MaxDepth + 1>> Accumulators;
@@ -62,7 +61,6 @@ private:
 
 	// Reused variables / stack
 	std::array<MoveList, MaxDepth> MoveListStack{};
-	std::array<Board, MaxDepth> Boards;
 	std::array<int, MaxDepth> StaticEvalStack;
 	std::array<int, MaxDepth> EvalStack;
 	std::array<MoveAndPiece, MaxDepth> MoveStack;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -487,7 +487,7 @@ constexpr std::array<bool, 64> OutpostFilter = {
 };
 
 // Randomly selected FENs from Renegade's games for benchmarking, might replace with something more standard
-const std::array<std::string, 19> BenchmarkFENs = {
+const std::array<std::string, 20> BenchmarkFENs = {
 	"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 	"2r3k1/2P2pp1/3Np2p/8/7P/5qP1/5P1K/2Q5 b - - 2 42",
 	"rnbqkb1r/pppppppp/8/3nP3/2P5/8/PP1P1PPP/RNBQKBNR b KQkq - 0 3",
@@ -506,7 +506,8 @@ const std::array<std::string, 19> BenchmarkFENs = {
 	"5k2/8/4p2p/4P1p1/3P2P1/3b3K/3B2P1/8 w - - 92 121",
 	"rnbqk2r/ppppppbp/5np1/8/2PP4/2N2N2/PP2PPPP/R1BQKB1R b KQkq - 3 4",
 	"2r1r1k1/p3B2p/3p1P2/2pP3q/P1P3n1/1R3p1P/2Q3P1/1R5K b - - 2 47",
-	"8/8/6R1/5K1p/8/5k2/6p1/8 w - - 0 79"
+	"8/8/6R1/5K1p/8/5k2/6p1/8 w - - 0 79",
+	"3k4/8/1Q6/1b6/8/1P1p1P2/3K4/7q b - - 7 64"
 };
 
 // Polyglot hashing numbers, taken from python-chess

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -487,7 +487,7 @@ constexpr std::array<bool, 64> OutpostFilter = {
 };
 
 // Randomly selected FENs from Renegade's games for benchmarking, might replace with something more standard
-const std::array<std::string, 15> BenchmarkFENs = {
+const std::array<std::string, 19> BenchmarkFENs = {
 	"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 	"2r3k1/2P2pp1/3Np2p/8/7P/5qP1/5P1K/2Q5 b - - 2 42",
 	"rnbqkb1r/pppppppp/8/3nP3/2P5/8/PP1P1PPP/RNBQKBNR b KQkq - 0 3",
@@ -502,7 +502,11 @@ const std::array<std::string, 15> BenchmarkFENs = {
 	"2r4k/5Qp1/p6p/3Np1b1/4P3/P7/1P2n1PP/2r2R1K w - - 1 33",
 	"3r4/5p1k/5bpP/8/4K1P1/2p1PN2/8/7R b - - 9 105",
 	"r1bqk2r/p1p1bppp/1p2pB2/8/3P4/3B1N2/PPP2PPP/R2QK2R b KQkq - 0 9",
-	"1rbqk2r/4ppb1/2np2p1/p1p4p/N1P1P3/4BP1P/PP1Q2P1/2KR1B1R w k - 1 15"
+	"1rbqk2r/4ppb1/2np2p1/p1p4p/N1P1P3/4BP1P/PP1Q2P1/2KR1B1R w k - 1 15",
+	"5k2/8/4p2p/4P1p1/3P2P1/3b3K/3B2P1/8 w - - 92 121",
+	"rnbqk2r/ppppppbp/5np1/8/2PP4/2N2N2/PP2PPPP/R1BQKB1R b KQkq - 3 4",
+	"2r1r1k1/p3B2p/3p1P2/2pP3q/P1P3n1/1R3p1P/2Q3P1/1R5K b - - 2 47",
+	"8/8/6R1/5K1p/8/5k2/6p1/8 w - - 0 79"
 };
 
 // Polyglot hashing numbers, taken from python-chess

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.1.0 dev 20";
+constexpr std::string_view Version = "1.1.0 dev 21";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This is a chonky one.

Board logic changes:
- Finally using make-unmake
- No longer copying a giant hash vector every make move
- Encoding castling as KxR
- Actual "is legal" function for verifying moves
- Handle null moves separately
- (probably more, I don't remember)

The code is really bad currently, but at least it works. It will be cleaned up later.

Also includes some changes to bench:
- Uses more positions
- Resetting search afterwards
- Added longbench command

And some other unintended stuff that I uncovered while coding this.

```
Elo   | 5.36 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9148 W: 2132 L: 1991 D: 5025
Penta | [49, 1001, 2325, 1158, 41]
https://renegadedev.eu.pythonanywhere.com/test/65/
```

Bench: 2372395