### PR TITLE
Net 23: input buckets based on the king's position

### DIFF
--- a/Renegade/Neurals.cpp
+++ b/Renegade/Neurals.cpp
@@ -90,6 +90,8 @@ int NeuralEvaluate(const Position& position) {
 	const uint8_t blackKingSq = position.BlackKingSquare();
 	AccumulatorRepresentation acc{};
 	acc.Reset();
+	acc.SetActiveBucket(Side::White, GetInputBucket(whiteKingSq, Side::White));
+	acc.SetActiveBucket(Side::Black, GetInputBucket(blackKingSq, Side::Black));
 
 	// Iterate through pieces and activate features
 	uint64_t bits = position.GetOccupancy();

--- a/Renegade/Neurals.cpp
+++ b/Renegade/Neurals.cpp
@@ -85,13 +85,14 @@ int NeuralEvaluate(const Position& position) {
 	alignas(64) std::array<int16_t, HiddenSize> hiddenBlack = std::array<int16_t, HiddenSize>();
 	for (int i = 0; i < HiddenSize; i++) hiddenWhite[i] = Network->FeatureBias[i];
 	for (int i = 0; i < HiddenSize; i++) hiddenBlack[i] = Network->FeatureBias[i];
+
+	const uint8_t whiteKingSq = position.WhiteKingSquare();
+	const uint8_t blackKingSq = position.BlackKingSquare();
 	AccumulatorRepresentation acc{};
 	acc.Reset();
 
 	// Iterate through pieces and activate features
 	uint64_t bits = position.GetOccupancy();
-	const uint8_t whiteKingSq = LsbSquare(position.WhiteKingBits());
-	const uint8_t blackKingSq = LsbSquare(position.BlackKingBits());
 	while (bits) {
 		const uint8_t sq = Popsquare(bits);
 		const uint8_t piece = position.GetPieceAt(sq);

--- a/Renegade/Neurals.h
+++ b/Renegade/Neurals.h
@@ -50,7 +50,7 @@ constexpr std::array<int, 32> InputBucketMap = {
 constexpr int InputBucketCount = 1;
 
 struct alignas(64) NetworkRepresentation {
-	std::array<std::array<int16_t, HiddenSize>, FeatureSize> FeatureWeights;
+	std::array<std::array<std::array<int16_t, HiddenSize>, FeatureSize>, InputBucketCount> FeatureWeights;
 	std::array<int16_t, HiddenSize> FeatureBias;
 	std::array<int16_t, HiddenSize * 2> OutputWeights;
 	int16_t OutputBias;
@@ -62,19 +62,29 @@ struct alignas(64) AccumulatorRepresentation {
 	std::array<int16_t, HiddenSize> White;
 	std::array<int16_t, HiddenSize> Black;
 
+	uint8_t WhiteBucket;
+	uint8_t BlackBucket;
+
 	void Reset() {
 		for (int i = 0; i < HiddenSize; i++) White[i] = Network->FeatureBias[i];
 		for (int i = 0; i < HiddenSize; i++) Black[i] = Network->FeatureBias[i];
+		WhiteBucket = 0;
+		BlackBucket = 0;
 	}
 
 	void AddFeature(const std::pair<int, int>& features) {
-		for (int i = 0; i < HiddenSize; i++) White[i] += Network->FeatureWeights[features.first][i];
-		for (int i = 0; i < HiddenSize; i++) Black[i] += Network->FeatureWeights[features.second][i];
+		for (int i = 0; i < HiddenSize; i++) White[i] += Network->FeatureWeights[WhiteBucket][features.first][i];
+		for (int i = 0; i < HiddenSize; i++) Black[i] += Network->FeatureWeights[BlackBucket][features.second][i];
 	}
 
 	void RemoveFeature(const std::pair<int, int>& features) {
-		for (int i = 0; i < HiddenSize; i++) White[i] -= Network->FeatureWeights[features.first][i];
-		for (int i = 0; i < HiddenSize; i++) Black[i] -= Network->FeatureWeights[features.second][i];
+		for (int i = 0; i < HiddenSize; i++) White[i] -= Network->FeatureWeights[WhiteBucket][features.first][i];
+		for (int i = 0; i < HiddenSize; i++) Black[i] -= Network->FeatureWeights[BlackBucket][features.second][i];
+	}
+
+	void SetActiveBucket(const bool side, const uint8_t bucket) {
+		if (side == Side::White) WhiteBucket = bucket;
+		else BlackBucket = bucket;
 	}
 
 };
@@ -101,6 +111,6 @@ inline std::pair<int, int> FeatureIndexes(const uint8_t piece, const uint8_t sq,
 inline int GetInputBucket(const uint8_t kingSq, const bool side) {
 	const uint8_t transform = side == Side::White ? 0 : 56;
 	const uint8_t rank = GetSquareRank(kingSq ^ transform);
-	const uint8_t file = GetSquareFile(kingSq ^ transform) ^ 7;
+	const uint8_t file = GetSquareFile(kingSq ^ transform) < 4 ? GetSquareFile(kingSq ^ transform) : (GetSquareFile(kingSq ^ transform) ^ 7);
 	return InputBucketMap[rank * 4 + file];
 }

--- a/Renegade/Neurals.h
+++ b/Renegade/Neurals.h
@@ -16,7 +16,7 @@
 
 // Network constants
 #ifndef NETWORK_NAME
-#define NETWORK_NAME "renegade-net-22-hm.bin"
+#define NETWORK_NAME "renegade-net-23-buckets.bin"
 #endif
 
 constexpr int FeatureSize = 768;
@@ -25,17 +25,7 @@ constexpr int Scale = 400;
 constexpr int QA = 255;
 constexpr int QB = 64;
 
-constexpr std::array<int, 32> InputBucketMap = {
-	0, 0, 0, 0,
-	0, 0, 0, 0,
-	0, 0, 0, 0,
-	0, 0, 0, 0,
-	0, 0, 0, 0,
-	0, 0, 0, 0,
-	0, 0, 0, 0,
-	0, 0, 0, 0,
-};
-/*
+
 constexpr std::array<int, 32> InputBucketMap = {
 	0, 0, 1, 1,
 	2, 2, 2, 2,
@@ -46,8 +36,7 @@ constexpr std::array<int, 32> InputBucketMap = {
 	3, 3, 3, 3,
 	3, 3, 3, 3,
 };
-*/
-constexpr int InputBucketCount = 1;
+constexpr int InputBucketCount = 4;
 
 struct alignas(64) NetworkRepresentation {
 	std::array<std::array<std::array<int16_t, HiddenSize>, FeatureSize>, InputBucketCount> FeatureWeights;

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -670,7 +670,8 @@ int Search::Evaluate(const Position& position, const int level) {
                    (Popcount(position.WhiteRookBits() | position.BlackRookBits())) * 2 +
                    (Popcount(position.WhiteQueenBits() | position.BlackQueenBits())) * 4;
 
-    int evaluation = NeuralEvaluate((*Accumulators)[level], position.Turn());
+    //int evaluation = NeuralEvaluate((*Accumulators)[level], position.Turn());
+	int evaluation = NeuralEvaluate(position);
 
 	return evaluation * (52 + std::min(24, gamePhase)) / 64;
 }
@@ -779,6 +780,7 @@ bool Search::StaticExchangeEval(const Position& position, const Move& move, cons
 // Accumulators for neural networks ---------------------------------------------------------------
 
 void Search::SetupAccumulators(const Position& position) {
+	/*
 	(*Accumulators)[0].Reset();
 	uint64_t bits = position.GetOccupancy();
 
@@ -789,11 +791,11 @@ void Search::SetupAccumulators(const Position& position) {
 		const uint8_t sq = Popsquare(bits);
 		const int piece = position.GetPieceAt(sq);
 		(*Accumulators)[0].AddFeature(FeatureIndexes(piece, sq, whiteKingSq, blackKingSq));
-	}
+	}*/
 }
 
 void Search::UpdateAccumulators(const Position& pos, const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece, const int level) {
-
+	/*
 	// Handle null moves
 	if (m.IsNull()) {
 		(*Accumulators)[level + 1] = (*Accumulators)[level];
@@ -805,7 +807,12 @@ void Search::UpdateAccumulators(const Position& pos, const Move& m, const uint8_
 
 	// Check if a refresh is necessary
 	if (TypeOfPiece(movedPiece) == PieceType::King) {
-		if (((GetSquareFile(m.from) < 4) && (GetSquareFile(m.to) >= 4)) || (GetSquareFile(m.from) >= 4) && (GetSquareFile(m.to) < 4)) {
+
+		const bool side = ColorOfPiece(movedPiece) == PieceColor::White ? Side::White : Side::Black;
+		const bool refreshFromMirroring = ((GetSquareFile(m.from) < 4) && (GetSquareFile(m.to) >= 4)) || ((GetSquareFile(m.from) >= 4) && (GetSquareFile(m.to) < 4));
+		const bool refreshFromBucketing = GetInputBucket(m.from, side) != GetInputBucket(m.to, side);
+
+		if (refreshFromMirroring || refreshFromBucketing) {
 			(*Accumulators)[level + 1].Reset();
 			uint64_t bits = pos.GetOccupancy();
 
@@ -873,7 +880,7 @@ void Search::UpdateAccumulators(const Position& pos, const Move& m, const uint8_
 			else Accumulator.RemoveFeature( FeatureIndexes(Piece::WhitePawn, m.to + 8, whiteKingSq, blackKingSq));
 			break;
 	}
-
+	*/
 }
 
 // PV table ---------------------------------------------------------------------------------------

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.1";
+constexpr std::string_view Version = "dev 1.1.3";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 19.14 +- 10.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2180 W: 574 L: 454 D: 1152
Penta | [11, 214, 525, 324, 16]
https://renegadedev.eu.pythonanywhere.com/test/128/
```

Renegade dev 1.1.3
Bench: 3076641