### PR TITLE
Simplify away the second killer move

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -20,33 +20,15 @@ void Histories::ClearKillerAndCounterMoves() {
 
 void Histories::AddKillerMove(const Move& move, const int level) {
 	if (level >= MaxDepth) return;
-	if (IsFirstKillerMove(move, level)) return;
-	if (IsSecondKillerMove(move, level)) {
-		KillerMoves[level][1] = KillerMoves[level][0];
-		KillerMoves[level][0] = move;
-		return;
-	}
-	KillerMoves[level][1] = KillerMoves[level][0];
-	KillerMoves[level][0] = move;
+	KillerMoves[level] = move;
 }
 
 bool Histories::IsKillerMove(const Move& move, const int level) const {
-	if (KillerMoves[level][0] == move) return true;
-	if (KillerMoves[level][1] == move) return true;
-	return false;
+	return KillerMoves[level] == move;
 }
 
-bool Histories::IsFirstKillerMove(const Move& move, const int level) const {
-	return KillerMoves[level][0] == move;
-}
-
-bool Histories::IsSecondKillerMove(const Move& move, const int level) const {
-	return KillerMoves[level][1] == move;
-}
-
-void Histories::ResetKillersForPly(const int level) {
-	KillerMoves[level][0] = EmptyMove;
-	KillerMoves[level][1] = EmptyMove;
+void Histories::ResetKillerForPly(const int level) {
+	KillerMoves[level] = EmptyMove;
 }
 
 void Histories::AddCountermove(const Move& previousMove, const Move& thisMove) {

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -16,9 +16,7 @@ public:
 	// Killer move heuristic:
 	void AddKillerMove(const Move& move, const int level);
 	bool IsKillerMove(const Move& move, const int level) const;
-	bool IsFirstKillerMove(const Move& move, const int level) const;
-	bool IsSecondKillerMove(const Move& move, const int level) const;
-	void ResetKillersForPly(const int level);
+	void ResetKillerForPly(const int level);
 
 	// Countermove heuristic:
 	void AddCountermove(const Move& previousMove, const Move& thisMove);
@@ -35,7 +33,7 @@ private:
 		value += amount - gravity;
 	}
 
-	std::array<std::array<Move, 2>, MaxDepth> KillerMoves;
+	std::array<Move, MaxDepth> KillerMoves;
 	std::array<std::array<Move, 64>, 64> CounterMoves;
 
 	using ThreatHistory = std::array<std::array<std::array<std::array<int16_t, 2>, 2>, 64>, 14>;

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -425,7 +425,7 @@ int Search::SearchRecursive(Position& position, int depth, const int level, int 
 		OrderMoves(position, MoveListStack[level], level, ttMove);
 
 		// Resetting killers and fail-high cutoff counts
-		if (level + 2 < MaxDepth) History.ResetKillersForPly(level + 2);
+		if (level + 2 < MaxDepth) History.ResetKillerForPly(level + 2);
 		if (level + 1 < MaxDepth) CutoffCount[level + 1] = 0;
 		if (level > 0) DoubleExtensions[level] = DoubleExtensions[level - 1];
 	}
@@ -943,8 +943,7 @@ int Search::CalculateOrderScore(const Position& position, const Move& m, const i
 	}
 
 	// Quiet killer moves
-	if (History.IsFirstKillerMove(m, level)) return 100100;
-	if (History.IsSecondKillerMove(m, level)) return 100000;
+	if (History.IsKillerMove(m, level)) return 100000;
 
 	// Countermove heuristic
 	if (level > 0 && useMoveStack && History.IsCountermove(position.GetPreviousMove(1).move, m)) return 99000;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.3";
+constexpr std::string_view Version = "dev 1.1.4";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Elo   | 1.28 +- 3.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14366 W: 3162 L: 3109 D: 8095
Penta | [58, 1651, 3716, 1696, 62]
https://renegadedev.eu.pythonanywhere.com/test/130/

Renegade dev 1.1.4
Bench: 4806289