### PR TITLE
Increase the minimum time usage

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -111,7 +111,7 @@ SearchConstraints Search::CalculateConstraints(const SearchParams params, const 
 		else {
 			// Time control with increment
 			maxTime = static_cast<int>(myTime * 0.25);
-			minTime = static_cast<int>(myTime * 0.019 + myInc * 0.7);
+			minTime = static_cast<int>(myTime * 0.023 + myInc * 0.7);
 		}
 
 		constraints.SearchTimeMax = maxTime;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.7";
+constexpr std::string_view Version = "dev 1.1.8";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 8.61 +- 6.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4762 W: 1139 L: 1021 D: 2602
Penta | [13, 481, 1283, 583, 21]
https://renegadedev.eu.pythonanywhere.com/test/145/
```

Renegade dev 1.1.8
Bench: 3316827