### PR TITLE
Material correction history

### DIFF
--- a/Renegade/Board.cpp
+++ b/Renegade/Board.cpp
@@ -252,3 +252,29 @@ void Board::ApplyMove(const Move& move, const CastlingConfiguration& castling) {
 	assert(Popcount(WhiteKingBits) == 1 && Popcount(BlackKingBits) == 1);
 }
 
+uint64_t Board::CalculateMaterialKey() const {
+    auto murmur_hash_3 = [](uint64_t key) -> std::uint64_t {
+        key ^= key >> 33;
+        key *= 0xff51afd7ed558ccd;
+        key ^= key >> 33;
+        key *= 0xc4ceb9fe1a85ec53;
+        key ^= key >> 33;
+        return key;
+    };
+
+    std::uint64_t material_key = 0;
+
+    material_key |= Popcount(this->WhitePawnBits);
+    material_key |= (Popcount(this->WhiteKnightBits) << 6);
+    material_key |= (Popcount(this->WhiteBishopBits) << 12);
+    material_key |= (Popcount(this->WhiteRookBits) << 18);
+    material_key |= (Popcount(this->WhiteQueenBits) << 24);
+
+    material_key |= (Popcount(this->BlackPawnBits) << 30);
+    material_key |= (Popcount(this->BlackKnightBits) << 36);
+    material_key |= (Popcount(this->BlackBishopBits) << 42);
+    material_key |= (Popcount(this->BlackRookBits) << 48);
+    material_key |= (Popcount(this->BlackQueenBits) << 54);
+
+    return murmur_hash_3(material_key);
+}

--- a/Renegade/Board.cpp
+++ b/Renegade/Board.cpp
@@ -253,7 +253,7 @@ void Board::ApplyMove(const Move& move, const CastlingConfiguration& castling) {
 }
 
 uint64_t Board::CalculateMaterialKey() const {
-    auto murmur_hash_3 = [](uint64_t key) -> std::uint64_t {
+    auto murmur_hash_3 = [](uint64_t key) -> uint64_t {
         key ^= key >> 33;
         key *= 0xff51afd7ed558ccd;
         key ^= key >> 33;
@@ -262,19 +262,19 @@ uint64_t Board::CalculateMaterialKey() const {
         return key;
     };
 
-    std::uint64_t material_key = 0;
+    uint64_t material_key = 0;
 
-    material_key |= Popcount(this->WhitePawnBits);
-    material_key |= (Popcount(this->WhiteKnightBits) << 6);
-    material_key |= (Popcount(this->WhiteBishopBits) << 12);
-    material_key |= (Popcount(this->WhiteRookBits) << 18);
-    material_key |= (Popcount(this->WhiteQueenBits) << 24);
+    material_key |= static_cast<uint64_t>(Popcount(this->WhitePawnBits));
+    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteKnightBits)) << 6);
+    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteBishopBits)) << 12);
+    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteRookBits)) << 18);
+    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteQueenBits)) << 24);
 
-    material_key |= (Popcount(this->BlackPawnBits) << 30);
-    material_key |= (Popcount(this->BlackKnightBits) << 36);
-    material_key |= (Popcount(this->BlackBishopBits) << 42);
-    material_key |= (Popcount(this->BlackRookBits) << 48);
-    material_key |= (Popcount(this->BlackQueenBits) << 54);
+    material_key |= (static_cast<uint64_t>(Popcount(this->BlackPawnBits)) << 30);
+    material_key |= (static_cast<uint64_t>(Popcount(this->BlackKnightBits)) << 36);
+    material_key |= (static_cast<uint64_t>(Popcount(this->BlackBishopBits)) << 42);
+    material_key |= (static_cast<uint64_t>(Popcount(this->BlackRookBits)) << 48);
+    material_key |= (static_cast<uint64_t>(Popcount(this->BlackQueenBits)) << 54);
 
     return murmur_hash_3(material_key);
 }

--- a/Renegade/Board.h
+++ b/Renegade/Board.h
@@ -95,6 +95,8 @@ struct Board {
 	uint64_t CalculateHash() const;
 	void ApplyMove(const Move& move, const CastlingConfiguration& castling);
 
+    uint64_t CalculateMaterialKey() const;
+
 };
 
 static_assert(sizeof(Board) == 176);

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -82,7 +82,7 @@ void Histories::UpdateCorrection(const Position& position, const int rawEval, co
 
     int32_t& value = MaterialCorrectionHistory[position.Turn()][material_key];
     value = ((256 - weight) * value + weight * diff) / 256;
-    value = std::clamp(value, -8'192, 8'192);
+    value = std::clamp(value, -12'288, 12'288);
 }
 
 int Histories::AdjustStaticEvaluation(const Position& position, const int rawEval) const {

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -75,8 +75,8 @@ int Histories::GetHistoryScore(const Position& position, const Move& m, const ui
 
 // Static evaluation correction history -----------------------------------------------------------
 
-void Histories::UpdateCorrection(const Position& position, const int16_t rawEval, const int16_t score, const int depth) {
-    const int material_key = position.GetMaterialKey() % 32768;
+void Histories::UpdateCorrection(const Position& position, const int rawEval, const int score, const int depth) {
+    const uint64_t material_key = position.GetMaterialKey() % 32768;
     const int diff = (score - rawEval) * 256;
     const int weight = std::min(16, depth + 1);
 
@@ -85,9 +85,7 @@ void Histories::UpdateCorrection(const Position& position, const int16_t rawEval
     value = std::clamp(value, -16'384, 16'384);
 }
 
-int Histories::AdjustStaticEvaluation(const Position& position, const int16_t rawEval) const {
-    if (std::abs(rawEval) > 10'000) return rawEval;
-
-    const int material_key = position.GetMaterialKey() % 32768;
+int Histories::AdjustStaticEvaluation(const Position& position, const int rawEval) const {
+    const uint64_t material_key = position.GetMaterialKey() % 32768;
     return rawEval + MaterialCorrectionHistory[position.Turn()][material_key] / 256;
 }

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -82,10 +82,12 @@ void Histories::UpdateCorrection(const Position& position, const int rawEval, co
 
     int32_t& value = MaterialCorrectionHistory[position.Turn()][material_key];
     value = ((256 - weight) * value + weight * diff) / 256;
-    value = std::clamp(value, -16'384, 16'384);
+    value = std::clamp(value, -8'192, 8'192);
 }
 
 int Histories::AdjustStaticEvaluation(const Position& position, const int rawEval) const {
+    if (std::abs(rawEval) > 10'000) return rawEval;
+
     const uint64_t material_key = position.GetMaterialKey() % 32768;
     return rawEval + MaterialCorrectionHistory[position.Turn()][material_key] / 256;
 }

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -27,8 +27,8 @@ public:
 	int GetHistoryScore(const Position& position, const Move& m, const uint8_t movedPiece, const int level) const;
 
     // Static evaluation correction history:
-    void UpdateCorrection(const Position& position, const int16_t staticEval, const int16_t score, const int depth);
-    int AdjustStaticEvaluation(const Position& position, const int16_t staticEval) const;
+    void UpdateCorrection(const Position& position, const int staticEval, const int score, const int depth);
+    int AdjustStaticEvaluation(const Position& position, const int staticEval) const;
 
 private:
 
@@ -48,6 +48,6 @@ private:
 
 	ThreatHistoryTable QuietHistory;
 	std::unique_ptr<ContinuationTable> Continuations;
-    std::array<std::array<int32_t, 32768>, 2> MaterialCorrectionHistory;
+    std::array<std::array<int, 32768>, 2> MaterialCorrectionHistory;
 };
 

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -26,6 +26,10 @@ public:
 	void UpdateHistory(const Position& position, const Move& m, const uint8_t piece, const int16_t delta, const int level);
 	int GetHistoryScore(const Position& position, const Move& m, const uint8_t movedPiece, const int level) const;
 
+    // Static evaluation correction history:
+    void UpdateCorrection(const Position& position, const int16_t staticEval, const int16_t score, const int depth);
+    int AdjustStaticEvaluation(const Position& position, const int16_t staticEval) const;
+
 private:
 
 	inline void UpdateHistoryValue(int16_t& value, const int amount) {
@@ -44,5 +48,6 @@ private:
 
 	ThreatHistoryTable QuietHistory;
 	std::unique_ptr<ContinuationTable> Continuations;
+    std::array<std::array<int32_t, 32768>, 2> MaterialCorrectionHistory;
 };
 

--- a/Renegade/Position.h
+++ b/Renegade/Position.h
@@ -127,7 +127,7 @@ public:
 	}
 
     inline uint64_t GetMaterialKey() const {
-        States.back().CalculateMaterialKey();
+        return States.back().CalculateMaterialKey();
     }
 
 	uint64_t AttackersOfSquare(const bool attackingSide, const uint8_t square) const;

--- a/Renegade/Position.h
+++ b/Renegade/Position.h
@@ -126,6 +126,10 @@ public:
 		return CheckBit(Threats.back(), sq);
 	}
 
+    inline uint64_t GetMaterialKey() const {
+        States.back().CalculateMaterialKey();
+    }
+
 	uint64_t AttackersOfSquare(const bool attackingSide, const uint8_t square) const;
 
 	inline uint64_t WhitePawnBits() const { return States.back().WhitePawnBits; }

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -314,7 +314,7 @@ int Search::SearchRecursive(Position& position, int depth, const int level, int 
 
 	if (!singularSearch) {
         rawEval = inCheck ? NoEval : Evaluate(position, level);
-		staticEval = History.AdjustStaticEvaluation(position, rawEval);
+		staticEval = inCheck ? NoEval : History.AdjustStaticEvaluation(position, rawEval);
 		eval = staticEval;
 
 		if ((ttEval != NoEval) && !inCheck) {  // inCheck is cosmetic
@@ -552,7 +552,9 @@ int Search::SearchRecursive(Position& position, int depth, const int level, int 
                    || (scoreType == ScoreType::UpperBound && bestScore < staticEval)
                    || (scoreType == ScoreType::LowerBound && bestScore > staticEval);
         }();
-        if (updateCorrection) History.UpdateCorrection(position, rawEval, bestScore, depth);
+        if (updateCorrection) {
+            History.UpdateCorrection(position, rawEval, bestScore, depth);
+        }
 
         TranspositionTable.Store(hash, depth, bestScore, scoreType, bestMove, level);
     }

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -314,7 +314,7 @@ int Search::SearchRecursive(Position& position, int depth, const int level, int 
 
 	if (!singularSearch) {
         rawEval = inCheck ? NoEval : Evaluate(position, level);
-		staticEval = inCheck ? NoEval : History.AdjustStaticEvaluation(position, rawEval);
+		staticEval = History.AdjustStaticEvaluation(position, rawEval);
 		eval = staticEval;
 
 		if ((ttEval != NoEval) && !inCheck) {  // inCheck is cosmetic

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -60,7 +60,6 @@ private:
 	std::vector<Move> GeneratePvLine() const;
 	void ResetPvTable();
 
-
 	int Depth, SelDepth;
 	uint64_t Nodes;
 	SearchStatistics Statistics;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.13";
+constexpr std::string_view Version = "dev 1.1.14";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Correct static evaluation based on material count history

Elo   | 7.59 +- 4.20 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 6778 W: 1559 L: 1411 D: 3808
Penta | [16, 731, 1755, 863, 24]

Bench: 2906830