### PR TITLE
Save raw evaluation into the transposition table

### DIFF
--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -4,7 +4,7 @@ Transpositions::Transpositions() {
 	SetSize(1); // set an initial size, it will be resized before using
 }
 
-void Transpositions::Store(const uint64_t hash, const int depth, int score, const int scoreType, const Move& bestMove, const int level) {
+void Transpositions::Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level) {
 
 	//assert(std::abs(score) > MateEval);
 	assert(HashMask != 0);
@@ -22,10 +22,11 @@ void Transpositions::Store(const uint64_t hash, const int depth, int score, cons
 		Table[key].scoreType = scoreType;
 		Table[key].hash = storedHash;
 		Table[key].quality = quality;
+		Table[key].rawEval = rawEval;
 
 		Table[key].score = [&] {
-			if (IsWinningMateScore(score)) return score + level;
-			if (IsLosingMateScore(score)) return score - level;
+			if (IsWinningMateScore(score)) return static_cast<int16_t>(score + level);
+			if (IsLosingMateScore(score)) return static_cast<int16_t>(score - level);
 			return score;
 		}();
 	}
@@ -42,6 +43,7 @@ bool Transpositions::Probe(const uint64_t& hash, TranspositionEntry& entry, cons
 		entry.scoreType = Table[key].scoreType;
 		entry.quality = Table[key].quality; // not needed
 		entry.hash = storedHash;
+		entry.rawEval = Table[key].rawEval;
 
 		entry.score = [&] {
 			const int32_t score = Table[key].score;

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -13,7 +13,8 @@ namespace ScoreType {
 
 struct TranspositionEntry {
 	uint32_t hash = 0;
-	int32_t score = 0;
+	int16_t score = 0;
+	int16_t rawEval = 0;
 	uint16_t quality = 0;
 	uint8_t depth = 0;
 	uint8_t scoreType = 0;
@@ -32,7 +33,7 @@ class Transpositions
 {
 public:
 	Transpositions();
-	void Store(const uint64_t hash, const int depth, int score, const int scoreType, const Move& bestMove, const int level);
+	void Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level);
 	bool Probe(const uint64_t& hash, TranspositionEntry& entry, const int level) const;
 	void Prefetch(const uint64_t hash) const;
 	void IncreaseAge();

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.23";
+constexpr std::string_view Version = "dev 1.1.24";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.00 +- 2.22 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 18298 W: 4004 L: 3846 D: 10448
Penta | [32, 1572, 5784, 1728, 33]
https://zzzzz151.pythonanywhere.com/test/1072/
```

Renegade dev 1.1.24
Bench: 3037862