### PR TITLE
Switching to a saner, and more conventional LMR scheme

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -597,7 +597,7 @@ int Search::SearchRecursive(ThreadData& t, Position& position, int depth, const 
 		int reduction = 0;
 		const int newDepth = depth - 1 + extension;
 
-		if ((legalMoveCount >= (pvNode ? 5 : 3)) && isQuiet && depth >= 3) {
+		if ((legalMoveCount >= (pvNode ? 6 : 4)) && isQuiet && depth >= 3) {
 			// Late move -> reduce
 
 			reduction = LMRTable[std::min(depth, 31)][std::min(legalMoveCount, 31)];

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.25";
+constexpr std::string_view Version = "dev 1.1.26";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
The previous implementation didn't make a whole lot of sense to me, and wanted to get rid of it for some time now. Finally, it passed non-regression.

```
Elo   | 1.94 +- 2.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 15184 W: 3334 L: 3249 D: 8601
Penta | [59, 1739, 3904, 1838, 52]
https://zzzzz151.pythonanywhere.com/test/1091/
```

Renegade dev 1.1.26
Bench: 2600745