### PR TITLE
Pawn structure correction history

### DIFF
--- a/Renegade/Board.cpp
+++ b/Renegade/Board.cpp
@@ -253,28 +253,19 @@ void Board::ApplyMove(const Move& move, const CastlingConfiguration& castling) {
 }
 
 uint64_t Board::CalculateMaterialKey() const {
-    auto murmur_hash_3 = [](uint64_t key) -> uint64_t {
-        key ^= key >> 33;
-        key *= 0xff51afd7ed558ccd;
-        key ^= key >> 33;
-        key *= 0xc4ceb9fe1a85ec53;
-        key ^= key >> 33;
-        return key;
-    };
-
     uint64_t material_key = 0;
 
-    material_key |= static_cast<uint64_t>(Popcount(this->WhitePawnBits));
-    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteKnightBits)) << 6);
-    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteBishopBits)) << 12);
-    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteRookBits)) << 18);
-    material_key |= (static_cast<uint64_t>(Popcount(this->WhiteQueenBits)) << 24);
+    material_key |= static_cast<uint64_t>(Popcount(WhitePawnBits));
+    material_key |= (static_cast<uint64_t>(Popcount(WhiteKnightBits)) << 6);
+    material_key |= (static_cast<uint64_t>(Popcount(WhiteBishopBits)) << 12);
+    material_key |= (static_cast<uint64_t>(Popcount(WhiteRookBits)) << 18);
+    material_key |= (static_cast<uint64_t>(Popcount(WhiteQueenBits)) << 24);
 
-    material_key |= (static_cast<uint64_t>(Popcount(this->BlackPawnBits)) << 30);
-    material_key |= (static_cast<uint64_t>(Popcount(this->BlackKnightBits)) << 36);
-    material_key |= (static_cast<uint64_t>(Popcount(this->BlackBishopBits)) << 42);
-    material_key |= (static_cast<uint64_t>(Popcount(this->BlackRookBits)) << 48);
-    material_key |= (static_cast<uint64_t>(Popcount(this->BlackQueenBits)) << 54);
+    material_key |= (static_cast<uint64_t>(Popcount(BlackPawnBits)) << 30);
+    material_key |= (static_cast<uint64_t>(Popcount(BlackKnightBits)) << 36);
+    material_key |= (static_cast<uint64_t>(Popcount(BlackBishopBits)) << 42);
+    material_key |= (static_cast<uint64_t>(Popcount(BlackRookBits)) << 48);
+    material_key |= (static_cast<uint64_t>(Popcount(BlackQueenBits)) << 54);
 
-    return murmur_hash_3(material_key);
+    return MurmurHash3(material_key);
 }

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -53,8 +53,10 @@ private:
 	CaptureHistoryTable CaptureHistory;
 	ContinuationHistoryTable ContinuationHistory;
 
-	// Correction history:
+	// Evaluation correction history:
 	using MaterialCorrectionTable = std::array<std::array<int32_t, 32768>, 2>;
+	using PawnsCorrectionTable = std::array<std::array<int32_t, 16384>, 2>;
 	MaterialCorrectionTable MaterialCorrectionHistory;
+	PawnsCorrectionTable PawnsCorrectionHistory;
 };
 

--- a/Renegade/Position.h
+++ b/Renegade/Position.h
@@ -122,7 +122,19 @@ public:
 
     inline uint64_t GetMaterialKey() const {
         return States.back().CalculateMaterialKey();
-    }
+	}
+
+	inline uint64_t GetPawnKey() const {
+		auto murmur_hash_3 = [](uint64_t key) -> uint64_t {
+			key ^= key >> 33;
+			key *= 0xff51afd7ed558ccd;
+			key ^= key >> 33;
+			key *= 0xc4ceb9fe1a85ec53;
+			key ^= key >> 33;
+			return key;
+		};
+		return murmur_hash_3(WhitePawnBits()) ^ murmur_hash_3(BlackPawnBits() ^ Zobrist[780]);
+	}
 
 	uint64_t AttackersOfSquare(const bool attackingSide, const uint8_t square) const;
 

--- a/Renegade/Position.h
+++ b/Renegade/Position.h
@@ -125,15 +125,7 @@ public:
 	}
 
 	inline uint64_t GetPawnKey() const {
-		auto murmur_hash_3 = [](uint64_t key) -> uint64_t {
-			key ^= key >> 33;
-			key *= 0xff51afd7ed558ccd;
-			key ^= key >> 33;
-			key *= 0xc4ceb9fe1a85ec53;
-			key ^= key >> 33;
-			return key;
-		};
-		return murmur_hash_3(WhitePawnBits()) ^ murmur_hash_3(BlackPawnBits() ^ Zobrist[780]);
+		return MurmurHash3(WhitePawnBits()) ^ MurmurHash3(BlackPawnBits() ^ Zobrist[780]);
 	}
 
 	uint64_t AttackersOfSquare(const bool attackingSide, const uint8_t square) const;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.28";
+constexpr std::string_view Version = "dev 1.1.29";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 
@@ -294,6 +294,15 @@ constexpr uint8_t Mirror(const uint8_t sq) {
 constexpr uint64_t SquareBit(const uint8_t sq) {
 	return 1ull << sq;
 }
+
+constexpr uint64_t MurmurHash3(uint64_t key) {
+	key ^= key >> 33;
+	key *= 0xff51afd7ed558ccd;
+	key ^= key >> 33;
+	key *= 0xc4ceb9fe1a85ec53;
+	key ^= key >> 33;
+	return key;
+};
 
 // String handling --------------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 4.73 +- 3.19 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 12272 W: 2759 L: 2592 D: 6921
Penta | [42, 1390, 3112, 1543, 49]
https://zzzzz151.pythonanywhere.com/test/1109/
```

Renegade dev 1.1.29
Bench: 3042528