### PR TITLE
Reenable and improve datagen

### DIFF
--- a/Renegade/Datagen.cpp
+++ b/Renegade/Datagen.cpp
@@ -47,7 +47,7 @@ void Datagen::Start(const std::optional<DatagenSettings> datagenSettings) {
 
 	std::vector<std::thread> threads = std::vector<std::thread>();
 	for (int i = 0; i < ThreadCount; i++) {
-		const std::string filenameForThread = filename + "_" + std::to_string(i + 1);
+		std::string filenameForThread = filename + "_" + std::to_string(i + 1);
 		threads.emplace_back(&Datagen::SelfPlay, this, filenameForThread);
 	}
 	for (std::thread& t : threads) t.join();
@@ -94,7 +94,7 @@ void Datagen::SelfPlay(const std::string filename) {
 		Position position = [&] {
 			if (!DFRC) return Position(FEN::StartPos);
 			else {
-				const std::uniform_int_distribution<std::size_t> distribution(0, 959);
+				std::uniform_int_distribution<std::size_t> distribution(0, 959);
 				const int whiteFrcIndex = distribution(generator);
 				const int blackFrcIndex = distribution(generator);
 				return Position(whiteFrcIndex, blackFrcIndex);
@@ -110,7 +110,7 @@ void Datagen::SelfPlay(const std::string filename) {
 				failed = true;
 				break;
 			}
-			const std::uniform_int_distribution<std::size_t> distribution(0, moves.size() - 1);
+			std::uniform_int_distribution<std::size_t> distribution(0, moves.size() - 1);
 			position.Push(moves[distribution(generator)].move);
 		}
 		if (failed) continue;

--- a/Renegade/Datagen.cpp
+++ b/Renegade/Datagen.cpp
@@ -26,9 +26,9 @@ void Datagen::Start(const std::optional<DatagenSettings> datagenSettings) {
 		ThreadCount = datagenSettings.value().threadCount;
 		DFRC = datagenSettings.value().doFRC;
 		
-		cout << "Filename: " << Console::White << filename << Console::Yellow << endl;
-		cout << "Thread count: " << Console::White << ThreadCount << Console::Yellow << endl;
-		cout << "Doing DFRC: " << Console::White << DFRC << Console::Yellow << '\n' << endl;
+		cout << "Filename: " << Console::Yellow << filename << Console::White << endl;
+		cout << "Thread count: " << Console::Yellow << ThreadCount << Console::White << endl;
+		cout << "Doing DFRC: " << Console::Yellow << DFRC << Console::White << '\n' << endl;
 	}
 
 	Settings::Chess960 = DFRC;

--- a/Renegade/Datagen.cpp
+++ b/Renegade/Datagen.cpp
@@ -205,7 +205,7 @@ void Datagen::SelfPlay(const std::string filename) {
 		}
 
 		// 6. Update display
-		if (Games.load(std::memory_order_relaxed) % 50 == 0) {
+		if (Games.load(std::memory_order_relaxed) % 1000 == 0) {
 			const auto endTime = Clock::now();
 			const int seconds = static_cast<int>((endTime - StartTime).count() / 1e9);
 			const int speed1 = PositionsAccepted.load(std::memory_order_relaxed) * 3600 / std::max(seconds, 1);
@@ -214,8 +214,8 @@ void Datagen::SelfPlay(const std::string filename) {
 			const std::string display = "Games: " + std::to_string(Games.load(std::memory_order_relaxed))
 				+ "  |  Positions accepted: " + std::to_string(PositionsAccepted.load(std::memory_order_relaxed))
 				+ "  |  Runtime: " + std::to_string(seconds) + "s  |  "
-				+ std::to_string(speed1) + " per hour  (" + std::to_string(speed2) + "/s/th)  ";
-			cout << display << '\r';
+				+ std::to_string(speed1) + " per hour  (" + std::to_string(speed2) + "/s/th)";
+			cout << display << endl; // '\r';
 		}
 
 	}

--- a/Renegade/Datagen.cpp
+++ b/Renegade/Datagen.cpp
@@ -1,25 +1,40 @@
-/*#include "Datagen.h"
+#include "Datagen.h"
 
-Datagen::Datagen() {
-	//
-}
+void Datagen::Start(const std::optional<DatagenSettings> datagenSettings) {
 
-void Datagen::Start() {
+	// Note: the optional is supported here, but not yet elsewhere in the code
 
 	Console::ClearScreen();
-	cout << Console::Highlight << " Renegade's datagen tool " << Console::White << "\n" << endl;
+	cout << Console::Highlight << " Renegade's datagen utility " << Console::White;
+	cout << " [" << Version << "]\n" << endl;
 
 	std::string filename;
-	cout << "Filename? " << Console::Yellow;
-	cin >> filename;
 
-	cout << Console::White << "How many threads? " << Console::Yellow;
-	cin >> ThreadCount;
+	if (!datagenSettings.has_value()) {
+		cout << "Filename? " << Console::Yellow;
+		cin >> filename;
 
-	cout << Console::White << "Do DRFC? " << Console::Yellow;
-	cin >> DFRC;
-	cout << Console::White << endl;
+		cout << Console::White << "How many threads? " << Console::Yellow;
+		cin >> ThreadCount;
+
+		cout << Console::White << "Do DRFC? " << Console::Yellow;
+		cin >> DFRC;
+		cout << Console::White << endl;
+	}
+	else {
+		filename = datagenSettings.value().filename;
+		ThreadCount = datagenSettings.value().threadCount;
+		DFRC = datagenSettings.value().doFRC;
+		
+		cout << "Filename: " << Console::White << filename << Console::Yellow << endl;
+		cout << "Thread count: " << Console::White << ThreadCount << Console::Yellow << endl;
+		cout << "Doing DFRC: " << Console::White << DFRC << Console::Yellow << '\n' << endl;
+	}
+
 	Settings::Chess960 = DFRC;
+	Settings::Hash = 1;
+	Settings::Threads = 1;
+	StartTime = Clock::now();
 
 	cout << "Datagen settings: " << endl;
 	cout << " - " << Console::Yellow << randomPlyBase << Console::White << " or " << Console::Yellow << randomPlyBase + 1
@@ -27,10 +42,31 @@ void Datagen::Start() {
 	cout << " - Verification at depth " << Console::Yellow << verificationDepth << Console::White
 		<< " with a threshold of " << Console::Yellow << startingEvalLimit << Console::White << endl;
 	cout << " - Playing with a soft node limit of " << Console::Yellow << softNodeLimit << Console::White << endl;
-	cout << " - Adjudication if mate is reported for 2 plies" << endl;
 	cout << " - Using DFRC starting positions: " << Console::Yellow << std::boolalpha << DFRC
 		<< std::noboolalpha << Console::White << "\n" << endl;
 
+	std::vector<std::thread> threads = std::vector<std::thread>();
+	for (int i = 0; i < ThreadCount; i++) {
+		const std::string filenameForThread = filename + "_" + std::to_string(i + 1);
+		threads.emplace_back(&Datagen::SelfPlay, this, filenameForThread);
+	}
+	for (std::thread& t : threads) t.join();
+}
+
+void Datagen::SelfPlay(const std::string filename) {
+
+	Search* Searcher1 = new Search;
+	Search* Searcher2 = new Search;
+	Search* SearcherV = new Search;
+	Searcher1->TranspositionTable.SetSize(1);
+	Searcher2->TranspositionTable.SetSize(1);
+	SearcherV->TranspositionTable.SetSize(1);
+	Searcher1->SetThreadCount(1);
+	Searcher2->SetThreadCount(1);
+	SearcherV->SetThreadCount(1);
+	Searcher1->DatagenMode = true;
+	Searcher2->DatagenMode = true;
+	SearcherV->DatagenMode = true;
 
 	SearchParams params = SearchParams();
 	params.softnodes = softNodeLimit;
@@ -38,56 +74,35 @@ void Datagen::Start() {
 	params.depth = depthLimit;
 	SearchParams verificationParams = SearchParams();
 	verificationParams.depth = verificationDepth;
-	Settings::Hash = 1;
-
-	StartTime = Clock::now();
-
-	std::vector<std::thread> threads = std::vector<std::thread>();
-	for (int i = 1; i <= ThreadCount; i++) {
-		std::string filenameForThread = filename + "_" + std::to_string(i);
-		threads.emplace_back(&Datagen::SelfPlay, this, filenameForThread, std::ref(params), std::ref(verificationParams), randomPlyBase, startingEvalLimit, i - 1);
-	}
-	for (std::thread& t : threads) t.join();
-
-}
-
-void Datagen::SelfPlay(const std::string filename, const SearchParams params, const SearchParams vParams,
-	const int randomPlyBase, const int startingEvalLimit, const int threadId) {
-
-	Search* Searcher1 = new Search;
-	Search* Searcher2 = new Search;
-
-	Searcher1->TranspositionTable.SetSize(Settings::Hash);
-	Searcher2->TranspositionTable.SetSize(Settings::Hash);
 	
-	Results results;
 	int gamesOnThread = 0;
 	std::mt19937 generator(std::random_device{}());
 
-	std::vector<std::pair<std::string, int>> CurrentFENs;
-	std::vector<std::string> unsavedFENs;
+	std::vector<std::pair<std::string, int>> currentGame;
+	std::vector<std::string> unsavedLines;
+
 
 	while (true) {
+
+		bool failed = false;
+		int winAdjudicationCounter = 0;
+		int drawAdjudicationCounter = 0;
+		GameState outcome = GameState();
+		currentGame.clear();
 
 		// 1. Reset state
 		Position position = [&] {
 			if (!DFRC) return Position(FEN::StartPos);
 			else {
-				std::uniform_int_distribution<std::size_t> distribution(0, 959);
+				const std::uniform_int_distribution<std::size_t> distribution(0, 959);
 				const int whiteFrcIndex = distribution(generator);
 				const int blackFrcIndex = distribution(generator);
 				return Position(whiteFrcIndex, blackFrcIndex);
 			}
-		}();
-		
-		Searcher1->ResetState(true);
-		Searcher2->ResetState(true);
-		Searcher1->DatagenMode = true;
-		Searcher2->DatagenMode = true;
-		bool failed = false;
+		}();		
 
 		// 2. Generate random moves from the start
-		const int randomPlies = (Games % 2 == 0) ? randomPlyBase : (randomPlyBase + 1);
+		const int randomPlies = (gamesOnThread % 2 == 0) ? randomPlyBase : (randomPlyBase + 1);
 		for (int i = 0; i < randomPlies; i++) {
 			MoveList moves{};
 			position.GenerateMoves(moves, MoveGen::All, Legality::Legal);
@@ -95,7 +110,7 @@ void Datagen::SelfPlay(const std::string filename, const SearchParams params, co
 				failed = true;
 				break;
 			}
-			std::uniform_int_distribution<std::size_t> distribution(0, moves.size() - 1);
+			const std::uniform_int_distribution<std::size_t> distribution(0, moves.size() - 1);
 			position.Push(moves[distribution(generator)].move);
 		}
 		if (failed) continue;
@@ -106,92 +121,105 @@ void Datagen::SelfPlay(const std::string filename, const SearchParams params, co
 		if (moves.size() == 0) continue;
 
 		// 3. Verify evaluation if acceptable
-		results = Searcher1->StartSearch(position, vParams, false);
-		if (std::abs(results.score) > startingEvalLimit) failed = true;
-		if (failed) continue;
-		Searcher1->ResetState(true);
+		const Results verificationResults = SearcherV->SearchSinglethreaded(position, verificationParams);
+		SearcherV->ResetState(true);
 
-		CurrentFENs.clear();
-		GameState outcome = GameState();
-		int adjudicationCounter = 0;
+		if (std::abs(verificationResults.score) > startingEvalLimit) failed = true;
+		if (failed) continue;
+
+		Searcher1->ResetState(true);
+		Searcher2->ResetState(true);
 
 		// 4. Play out the game
 		while (true) {
 			// Search
 			Search* currentSearcher = (position.Turn() == Side::White) ? Searcher1 : Searcher2;
-			results = currentSearcher->StartSearch(position, params, false);
+			const Results results = currentSearcher->SearchSinglethreaded(position, params);
+			const Move move = results.BestMove();
 			const int whiteScore = results.score * (position.Turn() == Side::Black ? -1 : 1);
 
 			// Adjudicate
-			if (std::abs(whiteScore) > MateThreshold) {
-				adjudicationCounter += 1;
-				if (adjudicationCounter >= 2) {
-					if (whiteScore > 0) outcome = GameState::WhiteVictory;
-					else outcome = GameState::BlackVictory;
+			if (std::abs(whiteScore) > 3000) {
+				winAdjudicationCounter += 1;
+				drawAdjudicationCounter = 0;
+
+				if (winAdjudicationCounter >= 2) {
+					outcome = (whiteScore > 0) ? GameState::WhiteVictory : GameState::BlackVictory;
 					break;
 				}
 			}
-			else adjudicationCounter = 0;
+			else winAdjudicationCounter = 0;
+
+			if (std::abs(whiteScore) < 5) {
+				winAdjudicationCounter = 0;
+				drawAdjudicationCounter += 1;
+
+				if (drawAdjudicationCounter >= 15) {
+					outcome = GameState::Draw;
+					break;
+				}
+			}
+			else drawAdjudicationCounter = 0;
 
 			if (position.GetPly() > 600) {
 				failed = true;
 				//cout << "\nGame too long: " << board.GetFEN() << endl;
 				break;
 			}
-			if (results.BestMove().IsNull()) {
+
+			if (move.IsNull()) {
 				failed = true;
 				cout << "\nGot null-move for " << position.GetFEN() << " with eval of " << results.score << endl;
 				break;
 			}
 
-			// Check position if it should be stored
-			PositionsTotal += 1;
-			if (!Filter(position, results.BestMove(), results.score)) {
-				PositionsAccepted += 1;
-				CurrentFENs.push_back(std::pair(position.GetFEN(), whiteScore));
+			// Check if position should be stored
+			PositionsTotal.fetch_add(1, std::memory_order_relaxed);
+			if (!Filter(position, move, results.score)) {
+				PositionsAccepted.fetch_add(1, std::memory_order_relaxed);
+				currentGame.push_back(std::pair(position.GetFEN(), whiteScore));
 			}
-			position.Push(results.BestMove());
-
+			position.Push(move);
 
 			outcome = position.GetGameState();
 			if (outcome != GameState::Playing) break;
-
 		}
 
 		if (failed) continue;
 
-		Games += 1;
+		Games.fetch_add(1, std::memory_order_relaxed);
 		gamesOnThread += 1;
 
-		// 5. Store the game
-		for (const auto& position : CurrentFENs) {
-			const std::string marlinformat = ToTextformat(position, outcome);
-			unsavedFENs.push_back(marlinformat);
+		// 5. Store the game to the memory, and periodically to the hard drive
+		for (const auto& [fen, whiteScore] : currentGame) {
+			unsavedLines.push_back(ToTextformat(fen, whiteScore, outcome));
 		}
-		if (gamesOnThread % 64 == 0) { // periodically save file
+		if (gamesOnThread % 64 == 0) {
 			std::ofstream file(filename, std::ios_base::app);
-			for (const auto& line : unsavedFENs) file << line << '\n';
+			const std::ostream_iterator<std::string> output_iterator(file, "\n");
+			std::copy(std::begin(unsavedLines), std::end(unsavedLines), output_iterator);
+
+			for (const auto& line : unsavedLines) file << line << '\n';
 			file.close();
-			unsavedFENs.clear();
+			unsavedLines.clear();
 		}
 
 		// 6. Update display
-		if (Games % 50 == 0) {
+		if (Games.load(std::memory_order_relaxed) % 50 == 0) {
 			const auto endTime = Clock::now();
 			const int seconds = static_cast<int>((endTime - StartTime).count() / 1e9);
-			const int speed1 = PositionsAccepted * 3600 / std::max(seconds, 1);
+			const int speed1 = PositionsAccepted.load(std::memory_order_relaxed) * 3600 / std::max(seconds, 1);
 			const int speed2 = speed1 / 3600 / ThreadCount;
 
-			std::string display = "";
-			display = "Games: " + std::to_string(Games) + "  |  Positions accepted: " + std::to_string(PositionsAccepted) + "  |  Runtime: "
-				+ std::to_string(seconds) + "s  |  " + std::to_string(speed1) + " per hour  (" + std::to_string(speed2) + "/s/th)";
+			const std::string display = "Games: " + std::to_string(Games.load(std::memory_order_relaxed))
+				+ "  |  Positions accepted: " + std::to_string(PositionsAccepted.load(std::memory_order_relaxed))
+				+ "  |  Runtime: " + std::to_string(seconds) + "s  |  "
+				+ std::to_string(speed1) + " per hour  (" + std::to_string(speed2) + "/s/th)  ";
 			cout << display << '\r';
 		}
 
-
 	}
 }
-
 
 bool Datagen::Filter(const Position& pos, const Move& move, const int eval) const {
 	if (std::abs(eval) > MateThreshold) return true;
@@ -202,76 +230,32 @@ bool Datagen::Filter(const Position& pos, const Move& move, const int eval) cons
 	return false;
 }
 
-std::string Datagen::ToTextformat(const std::pair<std::string, int>& position, const GameState outcome) const {
-	std::string outcomeStr;
-	switch (outcome) {
-	case GameState::WhiteVictory:
-		outcomeStr = "1.0"; break;
-	case GameState::BlackVictory:
-		outcomeStr = "0.0"; break;
-	case GameState::Draw:
-		outcomeStr = "0.5"; break;
-	default:
-		cout << "????" << endl;
-	}
-	return position.first + " | " + std::to_string(position.second) + " | " + outcomeStr;
-}
+std::string Datagen::ToTextformat(const std::string fen, const int16_t whiteScore, const GameState outcome) const {
+	// Format: <fen> | <eval> | <wdl>
+	// eval: white pov in cp, wdl 1.0 = white win, 0.0 = black win
 
-
-void Datagen::LowPlyFilter() const {
-	cout << "\nFiltering low ply entries\n";
-
-	// Ask for filename
-	cout << "Filename? ";
-	std::string filename;
-	cin >> filename;
-	cout << endl;
-
-	cout << "Min ply? ";
-	int minPly;
-	cin >> minPly;
-	cout << endl;
-
-	std::string outputName = filename + "_min" + std::to_string(minPly);
-
-	std::ofstream output;
-	output.open(outputName, std::ios_base::app);
-
-	// Read the file
-	std::ifstream ifs(filename);
-	std::string line;
-	
-	int counter = 0;
-
-	while (std::getline(ifs, line)) {
-		counter++;
-		if (counter % 1'000'000 == 0) cout << counter << endl;
-
-		const std::vector<std::string> parts = Split(line);
-		const int ply = (stoi(parts[5]) - 1) * 2 + (parts[1] == "w" ? 0 : 1);
-
-		if (ply < minPly) continue;
-		output << line << endl;
-	}
-	output.close();
-
-	cout << "Entry count: " << counter << endl;
-	cout << "Complete.\n" << endl;
+	const std::string outcomeStr = [&] {
+		switch (outcome) {
+		case GameState::WhiteVictory: return "1.0";
+		case GameState::BlackVictory: return "0.0";
+		case GameState::Draw: return "0.5";
+		default: return "???";
+		}
+	}();
+	return fen + " | " + std::to_string(whiteScore) + " | " + outcomeStr;
 }
 
 void Datagen::MergeFiles() const {
 	cout << "\nRenegade's file merging utility for datagen\n";
-
-	std::filesystem::path path = std::filesystem::current_path();
+	const std::filesystem::path path = std::filesystem::current_path();
 	cout << "Current folder: " << path << endl;
 
 	std::string name;
 	cout << "\nWhat is the base name of the generated files? ";
 	cin >> name;
 
-	std::vector<std::string> found;
-
 	// Iterate through files in directory
+	std::vector<std::string> found;
 	for (const auto& entry : std::filesystem::directory_iterator(path)) {
 		auto filename = entry.path().filename();
 		if (filename.string().starts_with(name)) {
@@ -280,32 +264,27 @@ void Datagen::MergeFiles() const {
 	}
 	cout << "Found " << found.size() << " files\n" << endl;
 
-
-	const std::string mergedName = name + "_merged";
-
 	// Write file
+	const std::string mergedName = name + "_merged";
 	std::ofstream output;
 	output.open(mergedName, std::ios_base::app);
 	int counter = 0;
 
 	for (const auto& filename : found) {
-
 		std::ifstream ifs(filename);
 		std::string line;
-
 
 		while (std::getline(ifs, line)) {
 			counter += 1;
 			if (counter % 1'000'000 == 0) cout << ".";
 			output << line << endl;
 		}
+
 		ifs.close();
 
 		cout << filename << " -> processed: " << counter << endl;
 	}
 
 	output.close();
-
 	cout << "\nComplete.\n" << endl;
-
-}*/
+}

--- a/Renegade/Datagen.h
+++ b/Renegade/Datagen.h
@@ -10,7 +10,7 @@
 
 struct DatagenSettings {
 	std::string filename{};
-	int threadCount = 0;
+	unsigned int threadCount = 0;
 	bool doFRC = false;
 };
 

--- a/Renegade/Datagen.h
+++ b/Renegade/Datagen.h
@@ -1,34 +1,26 @@
-/*#pragma once
+#pragma once
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <thread>
 #include "Position.h"
 #include "Search.h"
 #include "Settings.h"
 #include "Utils.h"
 
+struct DatagenSettings {
+	std::string filename{};
+	int threadCount = 0;
+	bool doFRC = false;
+};
+
 class Datagen
 {
 public:
-	Datagen();
-	void Start();
-	void SelfPlay(const std::string filename, const SearchParams params, const SearchParams vParams,
-		const int randomPlyBase, const int startingEvalLimit, const int threadId);
-	bool Filter(const Position& pos, const Move& move, const int eval) const;
-
-	std::string ToTextformat(const std::pair<std::string, int>& position, const GameState outcome) const;
-	// <fen> | <eval> | <wdl>
-	// eval: white pov in cp, wdl 1.0 = white win, 0.0 = black win
-	
-	void LowPlyFilter() const;
+	void Start(const std::optional<DatagenSettings> datagenSettings);
 	void MergeFiles() const;
 
-	uint64_t PositionsAccepted = 0;
-	uint64_t PositionsTotal = 0;
-	uint64_t Games = 0;
-	Clock::time_point StartTime;
-	int ThreadCount = 0;
-	bool DFRC = false;
+private:
 
 	// Datagen settings:
 	const int startingEvalLimit = 500;
@@ -39,5 +31,16 @@ public:
 	const int randomPlyBase = 10;
 	const int minSavePly = 16;
 
+	void SelfPlay(const std::string filename);
+	bool Filter(const Position& pos, const Move& move, const int eval) const;
+	std::string ToTextformat(const std::string fen, const int16_t whiteScore, const GameState outcome) const;
+
+	std::atomic<uint64_t> PositionsAccepted = 0;
+	std::atomic<uint64_t> PositionsTotal = 0;
+	std::atomic<uint64_t> Games = 0;
+
+	Clock::time_point StartTime;
+	int ThreadCount = 0;
+	bool DFRC = false;
+
 };
-*/

--- a/Renegade/Datagen.h
+++ b/Renegade/Datagen.h
@@ -8,16 +8,10 @@
 #include "Settings.h"
 #include "Utils.h"
 
-struct DatagenSettings {
-	std::string filename{};
-	unsigned int threadCount = 0;
-	bool doFRC = false;
-};
-
 class Datagen
 {
 public:
-	void Start(const std::optional<DatagenSettings> datagenSettings);
+	void Start(const bool quickStart);
 	void MergeFiles() const;
 
 private:
@@ -30,6 +24,11 @@ private:
 	const int depthLimit = 20;
 	const int randomPlyBase = 10;
 	const int minSavePly = 16;
+
+	const int drawAdjEvalThreshold = 5;
+	const int drawAdjPlies = 15;
+	const int winAdjEvalThreshold = 2000;
+	const int winAdjEvalPlies = 5;
 
 	void SelfPlay(const std::string filename);
 	bool Filter(const Position& pos, const Move& move, const int eval) const;

--- a/Renegade/Engine.cpp
+++ b/Renegade/Engine.cpp
@@ -29,8 +29,7 @@ void Engine::Start() {
 	// Handle externally receiving datagen
 	if (Behavior == EngineBehavior::Datagen) {
 		Datagen datagen = Datagen();
-		const DatagenSettings settings = { "datagen", std::thread::hardware_concurrency(), false };
-		datagen.Start(settings);
+		datagen.Start(true);
 		return;
 	}
 
@@ -86,7 +85,7 @@ void Engine::Start() {
 
 		if (cmd == "datagen") {
 			Datagen datagen = Datagen();
-			datagen.Start(std::nullopt);
+			datagen.Start(false);
 			continue;
 		}
 

--- a/Renegade/Engine.cpp
+++ b/Renegade/Engine.cpp
@@ -29,7 +29,8 @@ void Engine::Start() {
 	// Handle externally receiving datagen
 	if (Behavior == EngineBehavior::Datagen) {
 		Datagen datagen = Datagen();
-		datagen.Start(std::nullopt);
+		const DatagenSettings settings = { "datagen", std::thread::hardware_concurrency(), false };
+		datagen.Start(settings);
 		return;
 	}
 

--- a/Renegade/Engine.cpp
+++ b/Renegade/Engine.cpp
@@ -7,7 +7,8 @@ Engine::Engine(int argc, char* argv[]) {
 	LoadDefaultNetwork();
 	SearchThreads.TranspositionTable.SetSize(Settings::Hash);
 
-	if (argc == 2 && std::string(argv[1]) == "bench") QuitAfterBench = true;
+	if (argc == 2 && std::string(argv[1]) == "bench") Behavior = EngineBehavior::Bench;
+	else if (argc == 2 && std::string(argv[1]) == "datagen") Behavior = EngineBehavior::Datagen;
 	else PrintHeader();
 }
 
@@ -19,9 +20,16 @@ void Engine::PrintHeader() const {
 void Engine::Start() {
 
 	// Handle externally receiving bench
-	if (QuitAfterBench) {
+	if (Behavior == EngineBehavior::Bench) {
 		HandleBench();
 		SearchThreads.StopThreads();
+		return;
+	}
+
+	// Handle externally receiving datagen
+	if (Behavior == EngineBehavior::Datagen) {
+		Datagen datagen = Datagen();
+		datagen.Start(std::nullopt);
 		return;
 	}
 
@@ -75,22 +83,17 @@ void Engine::Start() {
 			continue;
 		}
 
-		/*if (cmd == "datagen") {
+		if (cmd == "datagen") {
 			Datagen datagen = Datagen();
-			datagen.Start();
+			datagen.Start(std::nullopt);
 			continue;
 		}
 
-		if (cmd == "filter") {
-			Datagen datagen = Datagen();
-			datagen.LowPlyFilter();
-			continue;
-		}
 		if (cmd == "merge") {
 			Datagen datagen = Datagen();
 			datagen.MergeFiles();
 			continue;
-		}*/
+		}
 
 		if (cmd == "tunetext") {
 			Tune::GenerateString();
@@ -496,8 +499,41 @@ void Engine::DrawBoard(const Position& pos, const uint64_t highlight) const {
 }
 
 void Engine::HandleBench() {
-	//cout << "123456 nodes 1200000 nps" << endl;
-	SearchThreads.SearchBench();
+	const int oldHashSize = Settings::Hash;
+	const bool oldChess960Setting = Settings::Chess960;
+	const int oldThreadCount = Settings::Threads;
+	Settings::Threads = 1;
+	Settings::Hash = 16;
+	SearchThreads.TranspositionTable.SetSize(16);
+	SearchThreads.SetThreadCount(1);
+
+	uint64_t nodes = 0;
+	SearchParams params{};
+	params.depth = 14;
+	const auto startTime = Clock::now();
+
+	for (std::string fen : BenchmarkFENs) {
+		Settings::Chess960 = StartsWith(fen, "[frc]");
+		if (StartsWith(fen, "[frc]")) fen = fen.substr(6, fen.length() - 6);
+		SearchThreads.ResetState(false);
+		const Position pos = Position(fen);
+
+		const Results r = SearchThreads.SearchSinglethreaded(pos, params);
+		nodes += r.nodes;
+	}
+
+	const auto endTime = Clock::now();
+	const int nps = static_cast<int>(nodes / ((endTime - startTime).count() / 1e9));
+	cout << nodes << " nodes " << nps << " nps" << endl;
+
+	SearchThreads.ResetState(false);
+	Settings::Hash = oldHashSize;
+	SearchThreads.TranspositionTable.SetSize(oldHashSize); // also clears the transposition table
+	// Some issues with the following code, but only when starting from the command line:
+	// Settings::Threads = oldThreadCount;
+	// SearchThreads.SetThreadCount(oldThreadCount);
+	// possibly starting and shutting down a thread too quickly?
+	Settings::Chess960 = oldChess960Setting;
 }
 
 void Engine::HandleCompiler() const {

--- a/Renegade/Engine.h
+++ b/Renegade/Engine.h
@@ -14,6 +14,8 @@
 
 void GenerateMagicTables();
 
+enum class EngineBehavior { Normal, Bench, Datagen };
+
 class Engine
 {
 public:
@@ -26,7 +28,7 @@ public:
 	void HandleCompiler() const;
 
 	Search SearchThreads;
-	bool QuitAfterBench = false;
+	EngineBehavior Behavior = EngineBehavior::Normal;
 
 #if defined(_MSC_VER)
 	const bool PrettySupport = true;

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -53,7 +53,7 @@ public:
 	std::thread Thread;
 	int threadId;
 	Results result;
-	bool bench = false;
+	bool singlethreaded = false;
 
 	inline bool IsMainThread() const {
 		return threadId == 0;
@@ -111,7 +111,7 @@ public:
 	void StartSearch(Position& position, const SearchParams params, const bool display);
 	void StopSearch();
 	void Loop(ThreadData& t);
-	void SearchBench();
+	Results SearchSinglethreaded(const Position& pos, const SearchParams& params);
 	void WaitUntilReady() const;
 
 	void Perft(Position& position, const int depth, const PerftType type) const;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.31";
+constexpr std::string_view Version = "dev 1.1.32";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit reenables the datagen functionality, and makes some additional changes:
- adds win and draw adjudication
- implements a quick start feature with default parameters if launched with `Renegade.exe bench`
- rewrites some old code
- adds a singlethreaded (blocking) search function, currently used by datagen and bench

A follow-up commit is being tested to make datagen require an opening book

Renegade dev 1.1.32
Bench: 2865493