### PR TITLE
Correction history indexed by the previous two moves

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -11,6 +11,7 @@ void Histories::ClearAll() {
 	std::memset(&ContinuationHistory, 0, sizeof(ContinuationHistoryTable));
     std::memset(&MaterialCorrectionHistory, 0, sizeof(MaterialCorrectionTable));
     std::memset(&PawnsCorrectionHistory, 0, sizeof(PawnsCorrectionTable));
+    std::memset(&LastMoveCorrectionHistory, 0, sizeof(LastMoveCorrectionTable));
 }
 
 void Histories::ClearKillerAndCounterMoves() {
@@ -109,6 +110,12 @@ void Histories::UpdateCorrection(const Position& position, const int16_t rawEval
 	int32_t& pawnValue = PawnsCorrectionHistory[position.Turn()][pawnKey];
 	pawnValue = ((256 - weight) * pawnValue + weight * diff) / 256;
 	pawnValue = std::clamp(pawnValue, -6144, 6144);
+
+	if (position.Moves.size() > 0) {
+		int32_t& lastMoveValue = LastMoveCorrectionHistory[position.GetPreviousMove(1).piece][position.GetPreviousMove(1).move.to];
+		lastMoveValue = ((256 - weight) * lastMoveValue + weight * diff) / 256;
+		lastMoveValue = std::clamp(lastMoveValue, -6144, 6144);
+	}
 }
 
 int16_t Histories::ApplyCorrection(const Position& position, const int16_t rawEval) const {
@@ -120,6 +127,13 @@ int16_t Histories::ApplyCorrection(const Position& position, const int16_t rawEv
 	const uint64_t pawnKey = position.GetPawnKey() % 16384;
 	const int pawnCorrection = PawnsCorrectionHistory[position.Turn()][pawnKey] / 256;
 
-	const int correctedEval = rawEval + materialCorrection + pawnCorrection;
+
+	const int lastMoveCorrection = [&] {
+		if (position.Moves.size() == 0) return 0;
+		const MoveAndPiece& lastMove = position.GetPreviousMove(1);
+		return LastMoveCorrectionHistory[lastMove.piece][lastMove.move.to] / 256;
+	}();
+
+	const int correctedEval = rawEval + (materialCorrection + pawnCorrection + lastMoveCorrection) * 2 / 3;
     return std::clamp(correctedEval, -MateThreshold + 1, MateThreshold - 1);
 }

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -56,7 +56,9 @@ private:
 	// Evaluation correction history:
 	using MaterialCorrectionTable = std::array<std::array<int32_t, 32768>, 2>;
 	using PawnsCorrectionTable = std::array<std::array<int32_t, 16384>, 2>;
+	using LastMoveCorrectionTable = std::array<std::array<int32_t, 64>, 14>;
 	MaterialCorrectionTable MaterialCorrectionHistory;
 	PawnsCorrectionTable PawnsCorrectionHistory;
+	LastMoveCorrectionTable LastMoveCorrectionHistory;
 };
 

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -56,9 +56,9 @@ private:
 	// Evaluation correction history:
 	using MaterialCorrectionTable = std::array<std::array<int32_t, 32768>, 2>;
 	using PawnsCorrectionTable = std::array<std::array<int32_t, 16384>, 2>;
-	using LastMoveCorrectionTable = std::array<std::array<int32_t, 64>, 14>;
+	using FollowUpCorrectionTable = std::array<std::array<std::array<std::array<int32_t, 64>, 14>, 64>, 14>;
 	MaterialCorrectionTable MaterialCorrectionHistory;
 	PawnsCorrectionTable PawnsCorrectionHistory;
-	LastMoveCorrectionTable LastMoveCorrectionHistory;
+	FollowUpCorrectionTable FollowUpCorrectionHistory;
 };
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.33";
+constexpr std::string_view Version = "dev 1.1.34";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Also dubbed as "concorrde", orginally passed in Motor, and it's based on ideas from a recent ice4 gainer.
I think Renegade might be the second engine to have this?

```
Elo   | 2.38 +- 1.92 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 33274 W: 7400 L: 7172 D: 18702
Penta | [101, 3855, 8512, 4053, 116]
https://zzzzz151.pythonanywhere.com/test/1181/
```

Renegade dev 1.1.34
Bench: 2856903