### PR TITLE
Using threats in capture history

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -66,11 +66,13 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 void Histories::UpdateCaptureHistory(const Position& position, const Move& m, const int16_t delta) {
 	const uint8_t attackingPiece = position.GetPieceAt(m.from);
 	const uint8_t targetSquare = m.to;
+	const bool fromSquareThreatened = position.IsSquareThreatened(m.from);
+	const bool toSquareThreatened = position.IsSquareThreatened(m.to);
 	const uint8_t capturedPiece = [&] {
 		if (m.flag != MoveFlag::EnPassantPerformed) return position.GetPieceAt(m.to);
 		else return (position.Turn() == Side::White) ? Piece::WhitePawn : Piece::BlackPawn;
 	}();
-	UpdateHistoryValue(CaptureHistory[attackingPiece][targetSquare][capturedPiece], delta);
+	UpdateHistoryValue(CaptureHistory[attackingPiece][targetSquare][capturedPiece][fromSquareThreatened][toSquareThreatened], delta);
 }
 
 int Histories::GetHistoryScore(const Position& position, const Move& m, const uint8_t movedPiece, const int level) const {
@@ -88,11 +90,13 @@ int Histories::GetHistoryScore(const Position& position, const Move& m, const ui
 int16_t Histories::GetCaptureHistoryScore(const Position& position, const Move& m) const {
 	const uint8_t attackingPiece = position.GetPieceAt(m.from);
 	const uint8_t targetSquare = m.to;
+	const bool fromSquareThreatened = position.IsSquareThreatened(m.from);
+	const bool toSquareThreatened = position.IsSquareThreatened(m.to);
 	const uint8_t capturedPiece = [&] {
 		if (m.flag != MoveFlag::EnPassantPerformed) return position.GetPieceAt(m.to);
 		else return (position.Turn() == Side::White) ? Piece::WhitePawn : Piece::BlackPawn;
 	}();
-	return CaptureHistory[attackingPiece][targetSquare][capturedPiece];
+	return CaptureHistory[attackingPiece][targetSquare][capturedPiece][fromSquareThreatened][toSquareThreatened];
 }
 
 // Static evaluation correction history -----------------------------------------------------------

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -46,7 +46,7 @@ private:
 	// Move ordering history:
 	using ThreatBuckets = std::array<std::array<int16_t, 2>, 2>;
 	using QuietHistoryTable = std::array<std::array<ThreatBuckets, 64>, 14>;
-	using CaptureHistoryTable = std::array<std::array<std::array<int16_t, 14>, 64>, 14>;  // [attacking piece][square to][captured piece]
+	using CaptureHistoryTable = std::array<std::array<std::array<ThreatBuckets, 14>, 64>, 14>;  // [attacking piece][square to][captured piece]
 	using ContinuationHistoryTable = std::array<std::array<std::array<std::array<int16_t, 64>, 14>, 64>, 14>;
 
 	QuietHistoryTable QuietHistory;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.37";
+constexpr std::string_view Version = "dev 1.1.38";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.35 +- 2.51 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 19200 W: 4217 L: 4032 D: 10951
Penta | [50, 2179, 4983, 2312, 76]
https://zzzzz151.pythonanywhere.com/test/1221/
```

Renegade dev 1.1.38
Bench: 2873887