### PR TITLE
Cutnode negative extension

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -546,7 +546,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			}
 			else {
 				// Extension check failed
-				if (!pvNode && (singularBeta >= beta)) return singularBeta; // Multicut
+				if (!pvNode && (singularBeta >= beta)) return singularBeta; //
+                else if (cutNode) extension = -2;
 			}
 		}
 

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -547,7 +547,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			else {
 				// Extension check failed
 				if (!pvNode && (singularBeta >= beta)) return singularBeta; //
-                else if (cutNode) extension = -2;
+                else if (cutNode) extension = -1;
 			}
 		}
 


### PR DESCRIPTION
Elo   | 3.16 +- 2.40 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 21248 W: 4688 L: 4495 D: 12065
Penta | [75, 2418, 5432, 2637, 62]