### PR TITLE
Adjust SEE margin in move ordering based on capthist

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -934,7 +934,11 @@ int Search::CalculateOrderScore(const ThreadData& t, const Position& position, c
 
 void Search::OrderMoves(const ThreadData& t, const Position& position, MoveList& ml, const int level, const Move& ttMove) {
 	for (auto& m : ml) {
-		const bool losingCapture = position.IsMoveQuiet(m.move) ? false : !StaticExchangeEval(position, m.move, 0);
+		const bool losingCapture = [&] {
+			if (position.IsMoveQuiet(m.move)) return false;
+			const int16_t captureScore = (m.move.IsPromotion()) ? 0 : t.History.GetCaptureHistoryScore(position, m.move);
+			return !StaticExchangeEval(position, m.move, -captureScore / 50);
+		}();
 		m.orderScore = CalculateOrderScore(t, position, m.move, level, ttMove, losingCapture, true);
 	}
 }

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.39";
+constexpr std::string_view Version = "dev 1.1.40";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 9.06 +- 4.74 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 5790 W: 1354 L: 1203 D: 3233
Penta | [20, 647, 1421, 776, 31]
https://zzzzz151.pythonanywhere.com/test/1272/
```

Renegade dev 1.1.40
Bench: 2451366
