### PR TITLE
Cleaner handling of en passants

### DIFF
--- a/Renegade/Board.cpp
+++ b/Renegade/Board.cpp
@@ -92,16 +92,7 @@ uint64_t Board::CalculateHash() const {
 
 	// En passant
 	if (EnPassantSquare != -1) {
-		bool hasPawn = false;
-		if (GetSquareFile(EnPassantSquare) != 0) {
-			if (Turn == Side::White) hasPawn = CheckBit(WhitePawnBits, EnPassantSquare - 9);
-			else hasPawn = CheckBit(BlackPawnBits, EnPassantSquare + 7);
-		}
-		if ((GetSquareFile(EnPassantSquare) != 7) && !hasPawn) {
-			if (Turn == Side::White) hasPawn = CheckBit(WhitePawnBits, EnPassantSquare - 7);
-			else hasPawn = CheckBit(BlackPawnBits, EnPassantSquare + 9);
-		}
-		if (hasPawn) hash ^= Zobrist[772 + GetSquareFile(EnPassantSquare)];
+		hash ^= Zobrist[772 + GetSquareFile(EnPassantSquare)];
 	}
 
 	if (Turn == Side::White) hash ^= Zobrist[780];
@@ -236,11 +227,18 @@ void Board::ApplyMove(const Move& move, const CastlingConfiguration& castling) {
 	}
 
 	// Update en passant
+	EnPassantSquare = -1;
 	if (move.flag == MoveFlag::EnPassantPossible) {
-		EnPassantSquare = (Turn == Side::White) ? move.to - 8 : move.to + 8;
-	}
-	else {
-		EnPassantSquare = -1;
+		if (Turn == Side::White) {
+			const bool pawnOnLeft = GetSquareFile(move.to) != 0 && GetPieceAt(move.to - 1) == Piece::BlackPawn;
+			const bool pawnOnRight = GetSquareFile(move.to) != 7 && GetPieceAt(move.to + 1) == Piece::BlackPawn;
+			if (pawnOnLeft || pawnOnRight) EnPassantSquare = move.to - 8;
+		}
+		else {
+			const bool pawnOnLeft = GetSquareFile(move.to) != 0 && GetPieceAt(move.to - 1) == Piece::WhitePawn;
+			const bool pawnOnRight = GetSquareFile(move.to) != 7 && GetPieceAt(move.to + 1) == Piece::WhitePawn;
+			if (pawnOnLeft || pawnOnRight) EnPassantSquare = move.to + 8;
+		}
 	}
 
 	// Update counters

--- a/Renegade/Board.cpp
+++ b/Renegade/Board.cpp
@@ -1,29 +1,5 @@
 #include "Board.h"
 
-Board::Board(const Board& b) {
-	WhitePawnBits = b.WhitePawnBits;
-	WhiteKnightBits = b.WhiteKnightBits;
-	WhiteBishopBits = b.WhiteBishopBits;
-	WhiteRookBits = b.WhiteRookBits;
-	WhiteQueenBits = b.WhiteQueenBits;
-	WhiteKingBits = b.WhiteKingBits;
-	BlackPawnBits = b.BlackPawnBits;
-	BlackKnightBits = b.BlackKnightBits;
-	BlackBishopBits = b.BlackBishopBits;
-	BlackRookBits = b.BlackRookBits;
-	BlackQueenBits = b.BlackQueenBits;
-	BlackKingBits = b.BlackKingBits;
-	EnPassantSquare = b.EnPassantSquare;
-	WhiteRightToShortCastle = b.WhiteRightToShortCastle;
-	WhiteRightToLongCastle = b.WhiteRightToLongCastle;
-	BlackRightToShortCastle = b.BlackRightToShortCastle;
-	BlackRightToLongCastle = b.BlackRightToLongCastle;
-	Turn = b.Turn;
-	HalfmoveClock = b.HalfmoveClock;
-	FullmoveClock = b.FullmoveClock;
-	Mailbox = b.Mailbox;
-}
-
 uint64_t Board::CalculateHash() const {
 	uint64_t hash = 0;
 

--- a/Renegade/Board.cpp
+++ b/Renegade/Board.cpp
@@ -94,12 +94,12 @@ uint64_t Board::CalculateHash() const {
 	if (EnPassantSquare != -1) {
 		bool hasPawn = false;
 		if (GetSquareFile(EnPassantSquare) != 0) {
-			if (Turn == Side::White) hasPawn = CheckBit(WhitePawnBits, EnPassantSquare - 7);
-			else hasPawn = CheckBit(BlackPawnBits, EnPassantSquare + 9);
-		}
-		if ((GetSquareFile(EnPassantSquare) != 7) && !hasPawn) {
 			if (Turn == Side::White) hasPawn = CheckBit(WhitePawnBits, EnPassantSquare - 9);
 			else hasPawn = CheckBit(BlackPawnBits, EnPassantSquare + 7);
+		}
+		if ((GetSquareFile(EnPassantSquare) != 7) && !hasPawn) {
+			if (Turn == Side::White) hasPawn = CheckBit(WhitePawnBits, EnPassantSquare - 7);
+			else hasPawn = CheckBit(BlackPawnBits, EnPassantSquare + 9);
 		}
 		if (hasPawn) hash ^= Zobrist[772 + GetSquareFile(EnPassantSquare)];
 	}

--- a/Renegade/Board.h
+++ b/Renegade/Board.h
@@ -19,7 +19,6 @@ struct Board {
 
 	Board() = default;
 	~Board() = default;
-	Board(const Board& b);
 
 	// Piece bitboards
 	uint64_t WhitePawnBits = 0;

--- a/Renegade/Position.cpp
+++ b/Renegade/Position.cpp
@@ -796,18 +796,7 @@ std::string Position::GetFEN() const {
 	}
 	result += ' ';
 
-	bool enPassantPossible = false;
-	if ((b.EnPassantSquare != -1) && (b.Turn == Side::White)) {
-		const bool fromRight = (((b.WhitePawnBits & ~File[0]) << 7) & SquareBit(b.EnPassantSquare));
-		const bool fromLeft = (((b.WhitePawnBits & ~File[7]) << 9) & SquareBit(b.EnPassantSquare));
-		if (fromLeft || fromRight) enPassantPossible = true;
-	}
-	if ((b.EnPassantSquare != -1) && (b.Turn == Side::Black)) {
-		const bool fromRight = (((b.BlackPawnBits & ~File[0]) >> 9) & SquareBit(b.EnPassantSquare));
-		const bool fromLeft = (((b.BlackPawnBits & ~File[7]) >> 7) & SquareBit(b.EnPassantSquare));
-		if (fromLeft || fromRight) enPassantPossible = true;
-	}
-	if (enPassantPossible) result += SquareStrings[b.EnPassantSquare];
+	if (b.EnPassantSquare != -1) result += SquareStrings[b.EnPassantSquare];
 	else result += '-';
 
 	result += ' ' + std::to_string(b.HalfmoveClock) + ' ' + std::to_string(b.FullmoveClock);

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.41";
+constexpr std::string_view Version = "dev 1.1.42";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Non-final version:

```
Elo   | 0.31 +- 1.92 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 33820 W: 7607 L: 7577 D: 18636
Penta | [152, 3903, 8772, 3929, 154]
https://zzzzz151.pythonanywhere.com/test/1300/
```

Renegade dev 1.1.42
Bench: 2877006