### PR TITLE
Net 28: partially regenerated training data, again

### DIFF
--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -16,7 +16,7 @@
 
 // Network constants
 #ifndef NETWORK_NAME
-#define NETWORK_NAME "renegade-net-26.bin"
+#define NETWORK_NAME "renegade-net-28.bin"
 #endif
 
 constexpr int FeatureSize = 768;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.44";
+constexpr std::string_view Version = "dev 1.1.45";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -6,7 +6,7 @@ use bullet_lib::{
     TrainerBuilder, TrainingSchedule, Loss, optimiser
 };
 
-const NET_ID: &str = "renegade-net-26";
+const NET_ID: &str = "renegade-net-28";
 
 
 fn main() {
@@ -61,7 +61,7 @@ fn main() {
     let settings = LocalSettings {
         threads: 6,
         data_file_paths: vec![
-            "../nnue/data/240609_240622_240722_240821_240928_frc240513",
+            "../nnue/data/240722_240821_240928_241010_frc241002",
         ],
         test_set: None,
         output_directory: "checkpoints",


### PR DESCRIPTION
Replacing the entire FRC data, and 1 billion positions of normal chess.

Normal chess:
```
Elo   | 3.84 +- 2.68 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.50]
Games | N: 18378 W: 4376 L: 4173 D: 9829
Penta | [95, 2138, 4523, 2335, 98]
https://zzzzz151.pythonanywhere.com/test/1388/
```

FRC:
```
Elo   | 10.20 +- 4.72 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.50]
Games | N: 5726 W: 967 L: 799 D: 3960
Penta | [36, 541, 1562, 667, 57]
https://zzzzz151.pythonanywhere.com/test/1389/
```

Bench: 2658706
Renegade dev 1.1.45