### PR TITLE
Increase history adjustments when pawn structures differ

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -54,7 +54,7 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 	const uint16_t lastPawnKey = QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked];
 	const uint16_t pawnKey = position.GetPawnKey() % 65536;
 	const bool pawnKeyChanged = lastPawnKey != pawnKey;
-	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], delta * (1 + pawnKeyChanged));
+	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], delta + 300 * pawnKeyChanged);
 	QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked] = pawnKey;
 
 	// Continuation history

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -54,7 +54,10 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 	const uint16_t lastPawnKey = QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked];
 	const uint16_t pawnKey = position.GetPawnKey() % 65536;
 	const bool pawnKeyChanged = lastPawnKey != pawnKey;
-	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], delta + 300 * pawnKeyChanged);
+	int16_t hdelta = delta;
+	if (pawnKeyChanged) hdelta += (delta > 0) ? 300 : -300;
+
+	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], hdelta);
 	QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked] = pawnKey;
 
 	// Continuation history

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -7,6 +7,7 @@ Histories::Histories() {
 void Histories::ClearAll() {
 	ClearKillerAndCounterMoves();
 	std::memset(&QuietHistory, 0, sizeof(QuietHistoryTable));
+	std::memset(&QuietHistoryStructure, 0, sizeof(QuietHistoryStructureTable));
 	std::memset(&CaptureHistory, 0, sizeof(CaptureHistoryTable));
 	std::memset(&ContinuationHistory, 0, sizeof(ContinuationHistoryTable));
     std::memset(&MaterialCorrectionHistory, 0, sizeof(MaterialCorrectionTable));
@@ -50,7 +51,11 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 	const bool side = ColorOfPiece(piece) == PieceColor::White;
 	const bool fromSquareAttacked = position.IsSquareThreatened(m.from);
 	const bool toSquareAttacked = position.IsSquareThreatened(m.to);
-	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], delta);
+	const uint16_t lastPawnKey = QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked];
+	const uint16_t pawnKey = position.GetPawnKey() % 65536;
+	const bool pawnKeyChanged = lastPawnKey != pawnKey;
+	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], delta * (1 + pawnKeyChanged));
+	QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked] = pawnKey;
 
 	// Continuation history
 	for (const int ply : { 1, 2, 4 }) {

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -49,9 +49,12 @@ private:
 	using CaptureHistoryTable = std::array<std::array<std::array<ThreatBuckets, 14>, 64>, 14>;  // [attacking piece][square to][captured piece]
 	using ContinuationHistoryTable = std::array<std::array<std::array<std::array<int16_t, 64>, 14>, 64>, 14>;
 
+	using QuietHistoryStructureTable = std::array<std::array<std::array<std::array<uint16_t, 2>, 2>, 64>, 14>;
+
 	QuietHistoryTable QuietHistory;
 	CaptureHistoryTable CaptureHistory;
 	ContinuationHistoryTable ContinuationHistory;
+	QuietHistoryStructureTable QuietHistoryStructure;
 
 	// Evaluation correction history:
 	using MaterialCorrectionTable = std::array<std::array<int32_t, 32768>, 2>;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.46";
+constexpr std::string_view Version = "dev 1.1.47";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This patch boosts history score adjustments if the pawn structure is different from when the score was last updated. The general idea is that if a history entry is stale, we should help it update more easily.

Further considerations:
- it's most likely enough to save only 8 bits per entry instead of 16
- the two tables could be rearranged in a way that the hash and the score is adjacent in memory (esp. if later tried with conthist)
- just to be sure, a simplification should be run later with always applying the larger adjustments

```
Elo   | 3.73 +- 2.60 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.50]
Games | N: 18276 W: 4096 L: 3900 D: 10280
Penta | [49, 2121, 4619, 2283, 66]
https://zzzzz151.pythonanywhere.com/test/1402/
```

Renegade dev 1.1.47
Bench: 2436629