### PR TITLE
Calculate reductions based on fail-low counts

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -491,6 +491,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	// Iterate through legal moves
 	int scoreType = ScoreType::UpperBound;
 	int legalMoveCount = 0;
+	int failLowCount = 0;
 	Move bestMove = EmptyMove;
 	int bestScore = NegativeInfinity;
 
@@ -566,7 +567,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		// Late-move reductions & principal variation search
 		if ((legalMoveCount >= (pvNode ? 6 : 4)) && isQuiet && depth >= 3) {
 			
-			int reduction = LMRTable[std::min(depth, 31)][std::min(legalMoveCount, 31)];
+			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!pvNode) reduction += 1;
 			if (inCheck) reduction -= 1;
 			if (t.CutoffCount[level] < 4) reduction -= 1;
@@ -593,6 +594,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Update node count table for the root
 		if (rootNode) t.RootNodeCounts[m.from][m.to] += t.Nodes - nodesBefore;
+
+		failLowCount += (score <= alpha);
 
 		// Process search results
 		if (score > bestScore) {

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.47";
+constexpr std::string_view Version = "dev 1.1.48";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
A cool idea from Alexandria's search rewrite

```
Elo   | 1.81 +- 1.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.50]
Games | N: 56340 W: 12302 L: 12009 D: 32029
Penta | [134, 6676, 14311, 6861, 188]
https://zzzzz151.pythonanywhere.com/test/1409/
```

Renegade dev 1.1.48
Bench: 2899227