### PR TITLE
Only do cutoffs in qsearch when being off-PV

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -378,7 +378,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 	// Drop into quiescence search at depth 0
 	if (depth <= 0) {
-		return SearchQuiescence(t, level, alpha, beta);
+		return SearchQuiescence(t, level, alpha, beta, pvNode);
 	}
 
 	const Move excludedMove = t.ExcludedMoves[level];
@@ -679,7 +679,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 }
 
 // Quiescence search: for noisy moves only (captures, queen promotions)
-int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta) {
+int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta, const bool pvNode) {
 
 	// Check search limits
 	const bool aborting = ShouldAbort(t);
@@ -692,6 +692,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 	const uint64_t hash = t.CurrentPosition.Hash();
 	TranspositionEntry ttEntry;
 	const bool found = TranspositionTable.Probe(hash, ttEntry, level);
+	if (!pvNode && found && ttEntry.IsCutoffPermitted(0, alpha, beta)) return ttEntry.score;
 
 	// Update alpha-beta bounds
 	const int rawEval = [&] {
@@ -703,10 +704,6 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 	if (staticEval > alpha) alpha = staticEval;
 	if (level >= MaxDepth) return staticEval;
 	if (t.CurrentPosition.IsDrawn(false)) return DrawEvaluation(t);
-	
-	if (found) {
-		if (ttEntry.IsCutoffPermitted(0, alpha, beta)) return ttEntry.score;
-	}
 
 	// Generate noisy moves and order them
 	t.MoveListStack[level].reset();
@@ -728,7 +725,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 		t.CurrentPosition.PushMove(m);
 		TranspositionTable.Prefetch(t.CurrentPosition.Hash());
 		UpdateAccumulators(t, t.CurrentPosition, m, movedPiece, capturedPiece, level);
-		const int score = -SearchQuiescence(t, level + 1, -beta, -alpha);
+		const int score = -SearchQuiescence(t, level + 1, -beta, -alpha, pvNode);
 		t.CurrentPosition.PopMove();
 
 		if (score > bestScore) {

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -131,7 +131,7 @@ private:
 
 	void SearchMoves(ThreadData& t);
 	int SearchRecursive(ThreadData& t, int depth, const int level, int alpha, int beta, const bool pvNode, const bool cutNode);
-	int SearchQuiescence(ThreadData& t, const int level, int alpha, int beta);
+	int SearchQuiescence(ThreadData& t, const int level, int alpha, int beta, const bool pvNode);
 
 	int Evaluate(const ThreadData& t, const Position& position, const int level);
 	uint64_t PerftRecursive(Position& position, const int depth, const int originalDepth, const PerftType type) const;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.49";
+constexpr std::string_view Version = "dev 1.1.50";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.75 +- 2.61 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.50]
Games | N: 18074 W: 4080 L: 3885 D: 10109
Penta | [50, 2088, 4573, 2269, 57]
https://zzzzz151.pythonanywhere.com/test/1417/
```

Renegade dev 1.1.50
Bench: 2731134