### PR TITLE
Decrease reductions in former PV nodes

### DIFF
--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -4,7 +4,7 @@ Transpositions::Transpositions() {
 	SetSize(1); // set an initial size, it will be resized before using
 }
 
-void Transpositions::Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level) {
+void Transpositions::Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level, const bool ttPv) {
 
 	//assert(std::abs(score) > MateEval);
 	assert(HashMask != 0);
@@ -23,6 +23,7 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 		Table[key].hash = storedHash;
 		Table[key].quality = quality;
 		Table[key].rawEval = rawEval;
+		Table[key].ttPv = ttPv;
 
 		Table[key].score = [&] {
 			if (IsWinningMateScore(score)) return static_cast<int16_t>(score + level);

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -19,6 +19,7 @@ struct TranspositionEntry {
 	uint8_t depth = 0;
 	uint8_t scoreType = 0;
 	uint16_t packedMove = 0;
+	bool ttPv = false;
 
 	inline bool IsCutoffPermitted(const int searchDepth, const int alpha, const int beta) const {
 		if (searchDepth > depth) return false;
@@ -33,7 +34,7 @@ class Transpositions
 {
 public:
 	Transpositions();
-	void Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level);
+	void Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level, const bool ttPv);
 	bool Probe(const uint64_t& hash, TranspositionEntry& entry, const int level) const;
 	void Prefetch(const uint64_t hash) const;
 	void IncreaseAge();

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.51";
+constexpr std::string_view Version = "dev 1.1.52";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Better known as ttPV, a speculative LTC was started after a few thousand games of STC:
```
Elo   | 2.13 +- 1.71 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.50]
Games | N: 38622 W: 8223 L: 7986 D: 22413
Penta | [38, 4401, 10203, 4624, 45]
https://zzzzz151.pythonanywhere.com/test/1482/
```

The unfinished STC:
```
Elo   | -0.12 +- 3.19 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.67 (-2.25, 2.89) [0.00, 3.50]
Games | N: 11636 W: 2532 L: 2536 D: 6568
Penta | [48, 1322, 3056, 1370, 22]
https://zzzzz151.pythonanywhere.com/test/1480/
```

Renegade dev 1.1.52
Bench: 2973085