### PR TITLE
Always double extend when only having one legal move

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -210,6 +210,7 @@ void Search::SearchMoves(ThreadData& t) {
 	t.ResetStatistics();
 	t.ResetPvTable();
 	std::fill(t.ExcludedMoves.begin(), t.ExcludedMoves.end(), EmptyMove);
+	std::fill(t.SuperSingular.begin(), t.SuperSingular.end(), false);
 	std::fill(t.CutoffCount.begin(), t.CutoffCount.end(), 0);
 	std::fill(t.DoubleExtensions.begin(), t.DoubleExtensions.end(), 0);
 	std::memset(&t.RootNodeCounts, 0, sizeof(t.RootNodeCounts));
@@ -427,6 +428,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		}
 		t.StaticEvalStack[level] = staticEval;
 		t.EvalStack[level] = eval;
+		t.SuperSingular[level] = false;
 	}
 	else {
 		staticEval = t.StaticEvalStack[level];
@@ -541,7 +543,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 				
 			if (singularScore < singularBeta) {
 				// Successful extension
-				const bool doubleExtend = !pvNode && (singularScore < singularBeta - 30) && (t.DoubleExtensions[level] < 6);
+				const bool doubleExtend = (!pvNode && (singularScore < singularBeta - 30) && (t.DoubleExtensions[level] < 6)) || t.SuperSingular[level];
 				if (doubleExtend) t.DoubleExtensions[level] += 1;
 				extension = 1 + doubleExtend;
 			}
@@ -621,7 +623,10 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 	// There was no legal move --> return mate or stalemate score
 	if (legalMoveCount == 0) {
-		if (singularSearch) return alpha; // always extend if we have only one legal move
+		if (singularSearch) {
+			t.SuperSingular[level] = true;
+			return alpha; // always extend if we have only one legal move
+		}
 		return inCheck ? LosingMateScore(level) : 0;
 	}
 

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -47,6 +47,7 @@ public:
 	std::array<int, MaxDepth> CutoffCount;
 	std::array<int, MaxDepth> DoubleExtensions;
 	std::array<Move, MaxDepth> ExcludedMoves;
+	std::array<bool, MaxDepth> SuperSingular;
 
 	Position CurrentPosition;
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.52";
+constexpr std::string_view Version = "dev 1.1.53";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This is being done in a bit of a silly way, because I didn't think it would pass, so will be cleaned up later.

```
Elo   | 2.66 +- 2.04 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.50]
Games | N: 28244 W: 6299 L: 6083 D: 15862
Penta | [78, 3144, 7472, 3340, 88]
https://zzzzz151.pythonanywhere.com/test/1515/
```

Renegade dev 1.1.53
Bench: 2993425