### PR TITLE
Fused NNUE updates

### DIFF
--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -110,6 +110,7 @@ void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& old
 			newAcc.Refresh(pos);
 			return;
 		}
+		newAcc.SetKingSquare(side, m.to);
 	}
 
 	// Case 3: Copy the previous state over - normal incremental update
@@ -119,16 +120,16 @@ void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& old
 
 	// (a) regular non-capture move
 	if (capturedPiece == Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed) {
-		newAcc.RemoveFeature(FeatureIndexes(movedPiece, m.from, whiteKingSq, blackKingSq));
-		newAcc.AddFeature(FeatureIndexes(movedPiece, m.to, whiteKingSq, blackKingSq));
+		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
+		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, m.to));
 		return;
 	}
 
 	// (b) regular capture move
 	if (capturedPiece != Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed && !m.IsCastling()) {
-		newAcc.RemoveFeature(FeatureIndexes(movedPiece, m.from, whiteKingSq, blackKingSq));
-		newAcc.AddFeature(FeatureIndexes(movedPiece, m.to, whiteKingSq, blackKingSq));
-		newAcc.RemoveFeature(FeatureIndexes(capturedPiece, m.to, whiteKingSq, blackKingSq));
+		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
+		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, m.to));
+		newAcc.RemoveFeature(newAcc.FeatureIndexes(capturedPiece, m.to));
 		return;
 	}
 
@@ -141,10 +142,10 @@ void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& old
 		const uint8_t newRookFile = shortCastle ? 5 : 3;
 		const uint8_t newKingSquare = newKingFile + (side == Side::Black) * 56;
 		const uint8_t newRookSquare = newRookFile + (side == Side::Black) * 56;
-		newAcc.RemoveFeature(FeatureIndexes(movedPiece, m.from, whiteKingSq, blackKingSq));
-		newAcc.RemoveFeature(FeatureIndexes(rookPiece, m.to, whiteKingSq, blackKingSq));
-		newAcc.AddFeature(FeatureIndexes(movedPiece, newKingSquare, whiteKingSq, blackKingSq));
-		newAcc.AddFeature(FeatureIndexes(rookPiece, newRookSquare, whiteKingSq, blackKingSq));
+		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
+		newAcc.RemoveFeature(newAcc.FeatureIndexes(rookPiece, m.to));
+		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, newKingSquare));
+		newAcc.AddFeature(newAcc.FeatureIndexes(rookPiece, newRookSquare));
 		return;
 	}
 
@@ -152,23 +153,23 @@ void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& old
 	if (m.IsPromotion()) {
 		const uint8_t promotionPiece = m.GetPromotionPieceType() + (ColorOfPiece(movedPiece) == PieceColor::Black ? Piece::BlackPieceOffset : 0);
 		if (capturedPiece == Piece::None) {
-			newAcc.AddFeature(FeatureIndexes(promotionPiece, m.to, whiteKingSq, blackKingSq));
-			newAcc.RemoveFeature(FeatureIndexes(movedPiece, m.from, whiteKingSq, blackKingSq));
+			newAcc.AddFeature(newAcc.FeatureIndexes(promotionPiece, m.to));
+			newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
 		}
 		else {
-			newAcc.AddFeature(FeatureIndexes(promotionPiece, m.to, whiteKingSq, blackKingSq));
-			newAcc.RemoveFeature(FeatureIndexes(movedPiece, m.from, whiteKingSq, blackKingSq));
-			newAcc.RemoveFeature(FeatureIndexes(capturedPiece, m.to, whiteKingSq, blackKingSq));
+			newAcc.AddFeature(newAcc.FeatureIndexes(promotionPiece, m.to));
+			newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
+			newAcc.RemoveFeature(newAcc.FeatureIndexes(capturedPiece, m.to));
 		}
 		return;
 	}
 
 	// (e) en passant
 	if (m.flag == MoveFlag::EnPassantPerformed) {
-		newAcc.RemoveFeature(FeatureIndexes(movedPiece, m.from, whiteKingSq, blackKingSq));
-		newAcc.AddFeature(FeatureIndexes(movedPiece, m.to, whiteKingSq, blackKingSq));
-		if (movedPiece == Piece::WhitePawn) newAcc.RemoveFeature(FeatureIndexes(Piece::BlackPawn, m.to - 8, whiteKingSq, blackKingSq));
-		else newAcc.RemoveFeature(FeatureIndexes(Piece::WhitePawn, m.to + 8, whiteKingSq, blackKingSq));
+		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
+		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, m.to));
+		if (movedPiece == Piece::WhitePawn) newAcc.RemoveFeature(newAcc.FeatureIndexes(Piece::BlackPawn, m.to - 8));
+		else newAcc.RemoveFeature(newAcc.FeatureIndexes(Piece::WhitePawn, m.to + 8));
 		return;
 	}
 

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -120,16 +120,16 @@ void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& old
 
 	// (a) regular non-capture move
 	if (capturedPiece == Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed) {
-		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
-		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, m.to));
+		newAcc.SubtractFeature(movedPiece, m.from);
+		newAcc.AddFeature(movedPiece, m.to);
 		return;
 	}
 
 	// (b) regular capture move
 	if (capturedPiece != Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed && !m.IsCastling()) {
-		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
-		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, m.to));
-		newAcc.RemoveFeature(newAcc.FeatureIndexes(capturedPiece, m.to));
+		newAcc.SubtractFeature(movedPiece, m.from);
+		newAcc.AddFeature(movedPiece, m.to);
+		newAcc.SubtractFeature(capturedPiece, m.to);
 		return;
 	}
 
@@ -142,10 +142,10 @@ void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& old
 		const uint8_t newRookFile = shortCastle ? 5 : 3;
 		const uint8_t newKingSquare = newKingFile + (side == Side::Black) * 56;
 		const uint8_t newRookSquare = newRookFile + (side == Side::Black) * 56;
-		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
-		newAcc.RemoveFeature(newAcc.FeatureIndexes(rookPiece, m.to));
-		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, newKingSquare));
-		newAcc.AddFeature(newAcc.FeatureIndexes(rookPiece, newRookSquare));
+		newAcc.SubtractFeature(movedPiece, m.from);
+		newAcc.SubtractFeature(rookPiece, m.to);
+		newAcc.AddFeature(movedPiece, newKingSquare);
+		newAcc.AddFeature(rookPiece, newRookSquare);
 		return;
 	}
 
@@ -153,23 +153,23 @@ void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& old
 	if (m.IsPromotion()) {
 		const uint8_t promotionPiece = m.GetPromotionPieceType() + (ColorOfPiece(movedPiece) == PieceColor::Black ? Piece::BlackPieceOffset : 0);
 		if (capturedPiece == Piece::None) {
-			newAcc.AddFeature(newAcc.FeatureIndexes(promotionPiece, m.to));
-			newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
+			newAcc.AddFeature(promotionPiece, m.to);
+			newAcc.SubtractFeature(movedPiece, m.from);
 		}
 		else {
-			newAcc.AddFeature(newAcc.FeatureIndexes(promotionPiece, m.to));
-			newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
-			newAcc.RemoveFeature(newAcc.FeatureIndexes(capturedPiece, m.to));
+			newAcc.AddFeature(promotionPiece, m.to);
+			newAcc.SubtractFeature(movedPiece, m.from);
+			newAcc.SubtractFeature(capturedPiece, m.to);
 		}
 		return;
 	}
 
 	// (e) en passant
 	if (m.flag == MoveFlag::EnPassantPerformed) {
-		newAcc.RemoveFeature(newAcc.FeatureIndexes(movedPiece, m.from));
-		newAcc.AddFeature(newAcc.FeatureIndexes(movedPiece, m.to));
-		if (movedPiece == Piece::WhitePawn) newAcc.RemoveFeature(newAcc.FeatureIndexes(Piece::BlackPawn, m.to - 8));
-		else newAcc.RemoveFeature(newAcc.FeatureIndexes(Piece::WhitePawn, m.to + 8));
+		newAcc.SubtractFeature(movedPiece, m.from);
+		newAcc.AddFeature(movedPiece, m.to);
+		if (movedPiece == Piece::WhitePawn) newAcc.SubtractFeature(Piece::BlackPawn, m.to - 8);
+		else newAcc.SubtractFeature(Piece::WhitePawn, m.to + 8);
 		return;
 	}
 

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -118,6 +118,10 @@ struct alignas(64) AccumulatorRepresentation {
 		for (int i = 0; i < HiddenSize; i++) Black[i] -= Network->FeatureWeights[BlackBucket][features.second][i];
 	}
 
+	// Fused NNUE updates are generally a speedup, however it seems to depend on the exact machine:
+	// failed to gain when tested on cloud workers, even though there was around a ~5% nps increase
+	// locally. For this reason this code stays for now, but it requires further investigation.
+
 	void SubAddFeature(const PieceAndSquare& f1, const PieceAndSquare& f2) {
 		const auto features1 = FeatureIndexes(f1.piece, f1.square);
 		const auto features2 = FeatureIndexes(f2.piece, f2.square);

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -115,6 +115,33 @@ struct alignas(64) AccumulatorRepresentation {
 		for (int i = 0; i < HiddenSize; i++) Black[i] -= Network->FeatureWeights[BlackBucket][features.second][i];
 	}
 
+	void AddSubFeature(const uint8_t piece1, const uint8_t sq1, const uint8_t piece2, const uint8_t sq2) {
+		const auto features1 = FeatureIndexes(piece1, sq1);
+		const auto features2 = FeatureIndexes(piece2, sq2);
+
+		for (int i = 0; i < HiddenSize; i++) White[i] +=
+			+ Network->FeatureWeights[WhiteBucket][features1.first][i]
+			- Network->FeatureWeights[WhiteBucket][features2.first][i];
+		for (int i = 0; i < HiddenSize; i++) Black[i] +=
+			+ Network->FeatureWeights[BlackBucket][features1.second][i]
+			- Network->FeatureWeights[BlackBucket][features2.second][i];
+	}
+
+	void AddSubSubFeature(const uint8_t piece1, const uint8_t sq1, const uint8_t piece2, const uint8_t sq2, const uint8_t piece3, const uint8_t sq3) {
+		const auto features1 = FeatureIndexes(piece1, sq1);
+		const auto features2 = FeatureIndexes(piece2, sq2);
+		const auto features3 = FeatureIndexes(piece3, sq3);
+
+		for (int i = 0; i < HiddenSize; i++) White[i] +=
+			+ Network->FeatureWeights[WhiteBucket][features1.first][i]
+			- Network->FeatureWeights[WhiteBucket][features2.first][i]
+			- Network->FeatureWeights[WhiteBucket][features3.first][i];
+		for (int i = 0; i < HiddenSize; i++) Black[i] +=
+			+ Network->FeatureWeights[BlackBucket][features1.second][i]
+			- Network->FeatureWeights[BlackBucket][features2.second][i]
+			- Network->FeatureWeights[BlackBucket][features3.second][i];
+	}
+
 	void SetKingSquare(const bool side, const uint8_t square) {
 		if (side == Side::White) WhiteKingSquare = square;
 		else BlackKingSquare = square;

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -120,7 +120,8 @@ struct alignas(64) AccumulatorRepresentation {
 
 	// Fused NNUE updates are generally a speedup, however it seems to depend on the exact machine:
 	// failed to gain when tested on cloud workers, even though there was around a ~5% nps increase
-	// locally. For this reason this code stays for now, but it requires further investigation.
+	// locally. For this reason this code stays for now, but it requires further investigation. Is
+	// it possible, that this optimization no longer gains due to better compilers getting better?
 
 	void SubAddFeature(const PieceAndSquare& f1, const PieceAndSquare& f2) {
 		const auto features1 = FeatureIndexes(f1.piece, f1.square);

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -99,16 +99,18 @@ struct alignas(64) AccumulatorRepresentation {
 		while (bits) {
 			const uint8_t sq = Popsquare(bits);
 			const uint8_t piece = pos.GetPieceAt(sq);
-			AddFeature(FeatureIndexes(piece, sq));
+			AddFeature(piece, sq);
 		}
 	}
 
-	void AddFeature(const std::pair<int, int>& features) {
+	void AddFeature(const uint8_t piece, const uint8_t sq) {
+		const auto features = FeatureIndexes(piece, sq);
 		for (int i = 0; i < HiddenSize; i++) White[i] += Network->FeatureWeights[WhiteBucket][features.first][i];
 		for (int i = 0; i < HiddenSize; i++) Black[i] += Network->FeatureWeights[BlackBucket][features.second][i];
 	}
 
-	void RemoveFeature(const std::pair<int, int>& features) {
+	void SubtractFeature(const uint8_t piece, const uint8_t sq) {
+		const auto features = FeatureIndexes(piece, sq);
 		for (int i = 0; i < HiddenSize; i++) White[i] -= Network->FeatureWeights[WhiteBucket][features.first][i];
 		for (int i = 0; i < HiddenSize; i++) Black[i] -= Network->FeatureWeights[BlackBucket][features.second][i];
 	}

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -48,6 +48,9 @@ struct alignas(64) NetworkRepresentation {
 extern const NetworkRepresentation* Network;
 
 
+struct PieceAndSquare {
+	uint8_t piece, square;
+};
 
 inline int GetInputBucket(const uint8_t kingSq, const bool side) {
 	const uint8_t transform = side == Side::White ? 0 : 56;
@@ -115,31 +118,31 @@ struct alignas(64) AccumulatorRepresentation {
 		for (int i = 0; i < HiddenSize; i++) Black[i] -= Network->FeatureWeights[BlackBucket][features.second][i];
 	}
 
-	void AddSubFeature(const uint8_t piece1, const uint8_t sq1, const uint8_t piece2, const uint8_t sq2) {
-		const auto features1 = FeatureIndexes(piece1, sq1);
-		const auto features2 = FeatureIndexes(piece2, sq2);
+	void SubAddFeature(const PieceAndSquare& f1, const PieceAndSquare& f2) {
+		const auto features1 = FeatureIndexes(f1.piece, f1.square);
+		const auto features2 = FeatureIndexes(f2.piece, f2.square);
 
 		for (int i = 0; i < HiddenSize; i++) White[i] +=
-			+ Network->FeatureWeights[WhiteBucket][features1.first][i]
-			- Network->FeatureWeights[WhiteBucket][features2.first][i];
+			- Network->FeatureWeights[WhiteBucket][features1.first][i]
+			+ Network->FeatureWeights[WhiteBucket][features2.first][i];
 		for (int i = 0; i < HiddenSize; i++) Black[i] +=
-			+ Network->FeatureWeights[BlackBucket][features1.second][i]
-			- Network->FeatureWeights[BlackBucket][features2.second][i];
+			- Network->FeatureWeights[BlackBucket][features1.second][i]
+			+ Network->FeatureWeights[BlackBucket][features2.second][i];
 	}
 
-	void AddSubSubFeature(const uint8_t piece1, const uint8_t sq1, const uint8_t piece2, const uint8_t sq2, const uint8_t piece3, const uint8_t sq3) {
-		const auto features1 = FeatureIndexes(piece1, sq1);
-		const auto features2 = FeatureIndexes(piece2, sq2);
-		const auto features3 = FeatureIndexes(piece3, sq3);
+	void SubSubAddFeature(const PieceAndSquare& f1, const PieceAndSquare& f2, const PieceAndSquare& f3) {
+		const auto features1 = FeatureIndexes(f1.piece, f1.square);
+		const auto features2 = FeatureIndexes(f2.piece, f2.square);
+		const auto features3 = FeatureIndexes(f3.piece, f3.square);
 
 		for (int i = 0; i < HiddenSize; i++) White[i] +=
-			+ Network->FeatureWeights[WhiteBucket][features1.first][i]
+			- Network->FeatureWeights[WhiteBucket][features1.first][i]
 			- Network->FeatureWeights[WhiteBucket][features2.first][i]
-			- Network->FeatureWeights[WhiteBucket][features3.first][i];
+			+ Network->FeatureWeights[WhiteBucket][features3.first][i];
 		for (int i = 0; i < HiddenSize; i++) Black[i] +=
-			+ Network->FeatureWeights[BlackBucket][features1.second][i]
+			- Network->FeatureWeights[BlackBucket][features1.second][i]
 			- Network->FeatureWeights[BlackBucket][features2.second][i]
-			- Network->FeatureWeights[BlackBucket][features3.second][i];
+			+ Network->FeatureWeights[BlackBucket][features3.second][i];
 	}
 
 	void SetKingSquare(const bool side, const uint8_t square) {

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -15,6 +15,7 @@
 #include <list>
 #include <mutex>
 #include <random>
+#include <thread>
 #include <tuple>
 
 /*

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.53";
+constexpr std::string_view Version = "dev 1.1.54";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Failed(!) testing:

```
Elo   | -0.14 +- 1.64 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=8MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.50]
Games | N: 38104 W: 8784 L: 8799 D: 20521
Penta | [136, 3626, 11572, 3553, 165]
https://zzzzz151.pythonanywhere.com/test/1586/
```

However, locally it is still a statistically significant speedup of around 5%.

Since the effectiveness of this patch seems to depend on the exact machine, the code stays, but a comment is also added as a reminder to revisit the neccessary of fused updates sometime in the future.

Renegade dev 1.1.54
Bench: 2993425