### PR TITLE
Only recalculate the side-to-move accumulator during a refresh

### DIFF
--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -197,12 +197,12 @@ struct alignas(64) AccumulatorRepresentation {
 		return { whiteFeatureIndex, blackFeatureIndex };
 	}
 
+	void UpdateFrom(const Position& pos, const AccumulatorRepresentation& oldAcc,
+		const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece);
+
 };
 
 int NeuralEvaluate(const Position& position);
 int NeuralEvaluate(const Position& position, const AccumulatorRepresentation& acc);
-
-void UpdateAccumulator(const Position& pos, const AccumulatorRepresentation& oldAcc, AccumulatorRepresentation& newAcc,
-	const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece);
 
 void LoadDefaultNetwork();

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -79,32 +79,50 @@ struct alignas(64) AccumulatorRepresentation {
 	std::array<int16_t, HiddenSize> Black;
 	uint8_t WhiteBucket, BlackBucket;
 	uint8_t WhiteKingSquare, BlackKingSquare;
+	bool SkipIncrementalForWhite, SkipIncrementalForBlack;
 
-	void Reset() {
-		for (int i = 0; i < HiddenSize; i++) White[i] = Network->FeatureBias[i];
-		for (int i = 0; i < HiddenSize; i++) Black[i] = Network->FeatureBias[i];
-		WhiteBucket = 0;
-		BlackBucket = 0;
-		WhiteKingSquare = 0;
-		BlackKingSquare = 0;
+	void RefreshBoth(const Position& pos) {
+		RefreshWhite(pos);
+		RefreshBlack(pos);
 	}
 
-	void Refresh(const Position& pos) {
-		Reset();
-		uint64_t bits = pos.GetOccupancy();
+	void RefreshWhite(const Position& pos) {
+		for (int i = 0; i < HiddenSize; i++) White[i] = Network->FeatureBias[i];
 		WhiteKingSquare = pos.WhiteKingSquare();
-		BlackKingSquare = pos.BlackKingSquare();
 		WhiteBucket = GetInputBucket(WhiteKingSquare, Side::White);
-		BlackBucket = GetInputBucket(BlackKingSquare, Side::Black);
-
+		
+		uint64_t bits = pos.GetOccupancy();
 		while (bits) {
 			const uint8_t sq = Popsquare(bits);
 			const uint8_t piece = pos.GetPieceAt(sq);
-			AddFeature(piece, sq);
+			AddFeatureWhite(piece, sq);
 		}
 	}
 
-	void AddFeature(const uint8_t piece, const uint8_t sq) {
+	void RefreshBlack(const Position& pos) {
+		for (int i = 0; i < HiddenSize; i++) Black[i] = Network->FeatureBias[i];
+		BlackKingSquare = pos.BlackKingSquare();
+		BlackBucket = GetInputBucket(BlackKingSquare, Side::Black);
+
+		uint64_t bits = pos.GetOccupancy();
+		while (bits) {
+			const uint8_t sq = Popsquare(bits);
+			const uint8_t piece = pos.GetPieceAt(sq);
+			AddFeatureBlack(piece, sq);
+		}
+	}
+
+	void AddFeatureWhite(const uint8_t piece, const uint8_t sq) {
+		const auto feature = FeatureIndexes(piece, sq).first;
+		for (int i = 0; i < HiddenSize; i++) White[i] += Network->FeatureWeights[WhiteBucket][feature][i];
+	}
+
+	void AddFeatureBlack(const uint8_t piece, const uint8_t sq) {
+		const auto feature = FeatureIndexes(piece, sq).second;
+		for (int i = 0; i < HiddenSize; i++) Black[i] += Network->FeatureWeights[BlackBucket][feature][i];
+	}
+
+	void AddFeatureBoth(const uint8_t piece, const uint8_t sq) {
 		const auto features = FeatureIndexes(piece, sq);
 		for (int i = 0; i < HiddenSize; i++) White[i] += Network->FeatureWeights[WhiteBucket][features.first][i];
 		for (int i = 0; i < HiddenSize; i++) Black[i] += Network->FeatureWeights[BlackBucket][features.second][i];
@@ -125,12 +143,16 @@ struct alignas(64) AccumulatorRepresentation {
 		const auto features1 = FeatureIndexes(f1.piece, f1.square);
 		const auto features2 = FeatureIndexes(f2.piece, f2.square);
 
-		for (int i = 0; i < HiddenSize; i++) White[i] +=
-			- Network->FeatureWeights[WhiteBucket][features1.first][i]
-			+ Network->FeatureWeights[WhiteBucket][features2.first][i];
-		for (int i = 0; i < HiddenSize; i++) Black[i] +=
-			- Network->FeatureWeights[BlackBucket][features1.second][i]
-			+ Network->FeatureWeights[BlackBucket][features2.second][i];
+		if (!SkipIncrementalForWhite) {
+			for (int i = 0; i < HiddenSize; i++) White[i] +=
+				- Network->FeatureWeights[WhiteBucket][features1.first][i]
+				+ Network->FeatureWeights[WhiteBucket][features2.first][i];
+		}
+		if (!SkipIncrementalForBlack) {
+			for (int i = 0; i < HiddenSize; i++) Black[i] +=
+				- Network->FeatureWeights[BlackBucket][features1.second][i]
+				+ Network->FeatureWeights[BlackBucket][features2.second][i];
+		}
 	}
 
 	void SubSubAddFeature(const PieceAndSquare& f1, const PieceAndSquare& f2, const PieceAndSquare& f3) {
@@ -138,14 +160,18 @@ struct alignas(64) AccumulatorRepresentation {
 		const auto features2 = FeatureIndexes(f2.piece, f2.square);
 		const auto features3 = FeatureIndexes(f3.piece, f3.square);
 
-		for (int i = 0; i < HiddenSize; i++) White[i] +=
-			- Network->FeatureWeights[WhiteBucket][features1.first][i]
-			- Network->FeatureWeights[WhiteBucket][features2.first][i]
-			+ Network->FeatureWeights[WhiteBucket][features3.first][i];
-		for (int i = 0; i < HiddenSize; i++) Black[i] +=
-			- Network->FeatureWeights[BlackBucket][features1.second][i]
-			- Network->FeatureWeights[BlackBucket][features2.second][i]
-			+ Network->FeatureWeights[BlackBucket][features3.second][i];
+		if (!SkipIncrementalForWhite) {
+			for (int i = 0; i < HiddenSize; i++) White[i] +=
+				- Network->FeatureWeights[WhiteBucket][features1.first][i]
+				- Network->FeatureWeights[WhiteBucket][features2.first][i]
+				+ Network->FeatureWeights[WhiteBucket][features3.first][i];
+		}
+		if (!SkipIncrementalForBlack) {
+			for (int i = 0; i < HiddenSize; i++) Black[i] +=
+				- Network->FeatureWeights[BlackBucket][features1.second][i]
+				- Network->FeatureWeights[BlackBucket][features2.second][i]
+				+ Network->FeatureWeights[BlackBucket][features3.second][i];
+		}
 	}
 
 	void SetKingSquare(const bool side, const uint8_t square) {

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -865,7 +865,7 @@ bool Search::StaticExchangeEval(const Position& position, const Move& move, cons
 // (the function names are very much awkward)
 
 void Search::SetupAccumulators(ThreadData& t, const Position& position) {
-	t.Accumulators[0].Refresh(position);
+	t.Accumulators[0].RefreshBoth(position);
 }
 
 void Search::UpdateAccumulators(ThreadData& t, const Position& pos, const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece, const int level) {

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -869,7 +869,7 @@ void Search::SetupAccumulators(ThreadData& t, const Position& position) {
 }
 
 void Search::UpdateAccumulators(ThreadData& t, const Position& pos, const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece, const int level) {
-	UpdateAccumulator(pos, t.Accumulators[level], t.Accumulators[level + 1], m, movedPiece, capturedPiece);
+	t.Accumulators[level + 1].UpdateFrom(pos, t.Accumulators[level], m, movedPiece, capturedPiece);
 }
 
 // PV table ---------------------------------------------------------------------------------------

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.56";
+constexpr std::string_view Version = "dev 1.1.57";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 12.62 +- 5.27 (95%)
SPRT  | 3.0+0.03s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.50]
Games | N: 4380 W: 1076 L: 917 D: 2387
Penta | [17, 419, 1171, 554, 29]
https://zzzzz151.pythonanywhere.com/test/1613/
```

Renegade dev 1.1.57
Bench: 2993425