### PR TITLE
Implement static vectors to avoid dynamic allocations

### DIFF
--- a/Renegade/Move.h
+++ b/Renegade/Move.h
@@ -132,52 +132,23 @@ struct ScoredMove {
 	int orderScore;
 };
 
-struct MoveList {
-	std::array<ScoredMove, MaxMoveCount> moves{};
-	int count = 0;
+struct MoveList : StaticVector<ScoredMove, MaxMoveCount> {
 
 	inline void pushUnscored(const Move& move) {
 		assert(count < MaxMoveCount);
-		moves[count] = { move, 0 };
+		items[count] = { move, 0 };
 		count += 1;
 	}
 
 	inline void pushScored(const Move& move, const int score) {
 		assert(count < MaxMoveCount);
-		moves[count] = { move, score };
+		items[count] = { move, score };
 		count += 1;
-	}
-
-	inline ScoredMove& operator[](const std::size_t index) {
-		return moves[index];
 	}
 
 	inline void setScore(const std::size_t index, const int score) {
 		assert(count > index);
-		moves[index].orderScore = score;
+		items[index].orderScore = score;
 	}
 
-	inline auto begin() const {
-		return moves.begin();
-	}
-
-	inline auto end() const {
-		return moves.begin() + static_cast<std::ptrdiff_t>(count);
-	}
-
-	inline auto begin() {
-		return moves.begin();
-	}
-
-	inline auto end() {
-		return moves.begin() + static_cast<std::ptrdiff_t>(count);
-	}
-
-	inline std::size_t size() const {
-		return count;
-	}
-
-	inline void reset() {
-		count = 0;
-	}
 };

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -479,7 +479,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	// (in singular search we've already done these)
 	if (!singularSearch) {
 		// Generating moves and ordering them
-		t.MoveListStack[level].reset();
+		t.MoveListStack[level].clear();
 		t.CurrentPosition.GenerateMoves(t.MoveListStack[level], MoveGen::All, Legality::Pseudolegal);
 		OrderMoves(t, t.CurrentPosition, t.MoveListStack[level], level, ttMove);
 
@@ -497,8 +497,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	Move bestMove = EmptyMove;
 	int bestScore = NegativeInfinity;
 
-	StaticVector<Move, 256> quietsTried;
-	StaticVector<Move, 256> capturesTried;
+	StaticVector<Move, MaxMoveCount> quietsTried;
+	StaticVector<Move, MaxMoveCount> capturesTried;
 
 	while (movePicker.hasNext()) {
 		const auto& [m, order] = movePicker.get();
@@ -712,7 +712,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 	if (t.CurrentPosition.IsDrawn(false)) return DrawEvaluation(t);
 
 	// Generate noisy moves and order them
-	t.MoveListStack[level].reset();
+	t.MoveListStack[level].clear();
 	t.CurrentPosition.GenerateMoves(t.MoveListStack[level], MoveGen::Noisy, Legality::Pseudolegal);
 	OrderMovesQ(t, t.CurrentPosition, t.MoveListStack[level], level, ttMove);
 	MovePicker movePicker(t.MoveListStack[level]);

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -497,10 +497,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	Move bestMove = EmptyMove;
 	int bestScore = NegativeInfinity;
 
-	std::vector<Move> quietsTried;
-	std::vector<Move> capturesTried;
-	capturesTried.reserve(10); // <-- ???
-	quietsTried.reserve(30); // <-- ???
+	StaticVector<Move, 256> quietsTried;
+	StaticVector<Move, 256> capturesTried;
 
 	while (movePicker.hasNext()) {
 		const auto& [m, order] = movePicker.get();
@@ -509,8 +507,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		legalMoveCount += 1;
 		const bool isQuiet = t.CurrentPosition.IsMoveQuiet(m);
 
-		if (isQuiet) quietsTried.push_back(m);
-		else capturesTried.push_back(m);
+		if (isQuiet) quietsTried.push(m);
+		else capturesTried.push(m);
 
 		// Moves loop pruning techniques
 		if (!pvNode && (bestScore > -MateThreshold) && (order < 90000) && !DatagenMode) {
@@ -649,8 +647,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Decrement history scores for all previously tried moves
 		if (depth > 1) {
-			if (quietBestMove) quietsTried.pop_back(); // don't decrement for the current move
-			else capturesTried.pop_back();
+			if (quietBestMove) quietsTried.pop(); // don't decrement for the current move
+			else capturesTried.pop();
 
 			for (const Move& prevTriedMove : quietsTried) {
 				const uint8_t prevTriedPiece = t.CurrentPosition.GetPieceAt(prevTriedMove.from);

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.62";
+constexpr std::string_view Version = "dev 1.1.63";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -355,6 +355,56 @@ namespace Internal {
 template<typename T, std::size_t... Ns>
 using MultiArray = typename Internal::MultiDimensionalArrayStruct<T, Ns...>::type;
 
+// Static vectors ---------------------------------------------------------------------------------
+// To avoid allocating memory in hot code paths
+
+template<typename T, std::size_t capacity>
+struct StaticVector {
+	inline void push(const T& item) {
+		assert(count < capacity);
+		items[count] = item;
+		count += 1;
+	}
+
+	inline void pop() {
+		assert(count != 0);
+		count -= 1;
+	}
+
+	inline void clear() {
+		count = 0;
+	}
+
+	inline T& operator[](const std::size_t index) {
+		assert(index < count);
+		return moves[index];
+	}
+
+	inline std::size_t size() {
+		return count;
+	}
+
+	inline auto begin() const {
+		return items.begin();
+	}
+
+	inline auto end() const {
+		return items.begin() + static_cast<std::ptrdiff_t>(count);
+	}
+
+	inline auto begin() {
+		return items.begin();
+	}
+
+	inline auto end() {
+		return items.begin() + static_cast<std::ptrdiff_t>(count);
+	}
+
+private:
+	std::array<T, capacity> items{};
+	std::size_t count = 0;
+};
+
 // Precomputed arrays -----------------------------------------------------------------------------
 
 constexpr std::array<uint64_t, 64> KingMoveBits = {

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -377,7 +377,7 @@ struct StaticVector {
 
 	inline T& operator[](const std::size_t index) {
 		assert(index < count);
-		return moves[index];
+		return items[index];
 	}
 
 	inline std::size_t size() {
@@ -400,7 +400,7 @@ struct StaticVector {
 		return items.begin() + static_cast<std::ptrdiff_t>(count);
 	}
 
-private:
+protected:
 	std::array<T, capacity> items{};
 	std::size_t count = 0;
 };


### PR DESCRIPTION
```
Elo   | 1.81 +- 2.45 (95%)
SPRT  | 3.0+0.03s Threads=1 Hash=4MB
LLR   | 2.89 (-2.25, 2.89) [-3.50, 0.00]
Games | N: 18240 W: 4266 L: 4171 D: 9803
Penta | [78, 1781, 5328, 1834, 99]
https://zzzzz151.pythonanywhere.com/test/1650/
```

Renegade dev 1.1.63
Bench: 2993425