### PR TITLE
Always apply quiet history boost regardless of pawn structure changes

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -46,14 +46,13 @@ bool Histories::IsCountermove(const Move& previousMove, const Move& thisMove) co
 
 void Histories::UpdateHistory(const Position& position, const Move& m, const uint8_t piece, const int16_t delta, const int level) {
 
-	// Main quiet history
+	// Main quiet history (note that we manually increase the delta here)
 	const bool side = ColorOfPiece(piece) == PieceColor::White;
 	const bool fromSquareAttacked = position.IsSquareThreatened(m.from);
 	const bool toSquareAttacked = position.IsSquareThreatened(m.to);
-	int16_t hdelta = delta;
-	hdelta += (delta > 0) ? 300 : -300;
-
-	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], hdelta);
+	int16_t quietHistoryDelta = delta;
+	quietHistoryDelta += (delta > 0) ? 300 : -300;
+	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], quietHistoryDelta);
 
 	// Continuation history
 	for (const int ply : { 1, 2, 4 }) {

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -55,7 +55,7 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 	const uint16_t pawnKey = position.GetPawnKey() % 65536;
 	const bool pawnKeyChanged = lastPawnKey != pawnKey;
 	int16_t hdelta = delta;
-	if (pawnKeyChanged) hdelta += (delta > 0) ? 300 : -300;
+	if (true) hdelta += (delta > 0) ? 300 : -300;
 
 	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], hdelta);
 	QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked] = pawnKey;

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -50,8 +50,7 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 	const bool side = ColorOfPiece(piece) == PieceColor::White;
 	const bool fromSquareAttacked = position.IsSquareThreatened(m.from);
 	const bool toSquareAttacked = position.IsSquareThreatened(m.to);
-	int16_t quietHistoryDelta = delta;
-	quietHistoryDelta += (delta > 0) ? 300 : -300;
+	const int16_t quietHistoryDelta = delta + ((delta > 0) ? 300 : -300);
 	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], quietHistoryDelta);
 
 	// Continuation history

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -7,7 +7,6 @@ Histories::Histories() {
 void Histories::ClearAll() {
 	ClearKillerAndCounterMoves();
 	std::memset(&QuietHistory, 0, sizeof(QuietHistoryTable));
-	std::memset(&QuietHistoryStructure, 0, sizeof(QuietHistoryStructureTable));
 	std::memset(&CaptureHistory, 0, sizeof(CaptureHistoryTable));
 	std::memset(&ContinuationHistory, 0, sizeof(ContinuationHistoryTable));
 	std::memset(&MaterialCorrectionHistory, 0, sizeof(MaterialCorrectionTable));
@@ -51,14 +50,10 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 	const bool side = ColorOfPiece(piece) == PieceColor::White;
 	const bool fromSquareAttacked = position.IsSquareThreatened(m.from);
 	const bool toSquareAttacked = position.IsSquareThreatened(m.to);
-	const uint16_t lastPawnKey = QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked];
-	const uint16_t pawnKey = position.GetPawnKey() % 65536;
-	const bool pawnKeyChanged = lastPawnKey != pawnKey;
 	int16_t hdelta = delta;
-	if (true) hdelta += (delta > 0) ? 300 : -300;
+	hdelta += (delta > 0) ? 300 : -300;
 
 	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], hdelta);
-	QuietHistoryStructure[piece][m.to][fromSquareAttacked][toSquareAttacked] = pawnKey;
 
 	// Continuation history
 	for (const int ply : { 1, 2, 4 }) {

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -47,13 +47,9 @@ private:
 	using QuietHistoryTable = MultiArray<int16_t, 15, 64, 2, 2>;
 	using CaptureHistoryTable = MultiArray<int16_t, 15, 64, 15, 2, 2>; // [attacking piece][square to][captured piece]
 	using ContinuationHistoryTable = MultiArray<int16_t, 15, 64, 15, 64>;
-
-	using QuietHistoryStructureTable = MultiArray<uint16_t, 15, 64, 2, 2>;
-
 	QuietHistoryTable QuietHistory;
 	CaptureHistoryTable CaptureHistory;
 	ContinuationHistoryTable ContinuationHistory;
-	QuietHistoryStructureTable QuietHistoryStructure;
 
 	// Evaluation correction history:
 	using MaterialCorrectionTable = MultiArray<int32_t, 2, 32768>;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.65";
+constexpr std::string_view Version = "dev 1.1.66";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This simplifies #61, it's a bit of a bummer, but good to know nevertheless.

```
Elo   | 1.16 +- 2.20 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.50, 0.00]
Games | N: 24882 W: 5416 L: 5333 D: 14133
Penta | [74, 2897, 6414, 2984, 72]
https://zzzzz151.pythonanywhere.com/test/1666/
```

Renegade dev 1.1.66
Bench: 2816679