### PR TITLE
Lazy NNUE updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2024 Krisztián Peőcz
+Copyright (c) 2022-2025 Krisztián Peőcz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -97,6 +97,9 @@ int16_t NeuralEvaluate(const Position& position) {
 void AccumulatorRepresentation::UpdateFrom(const Board& b, const AccumulatorRepresentation& oldAcc,
 	const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece) {
 
+	WhiteGood = true;
+	BlackGood = true;
+
 	// 1. For null-moves nothing changes, we just copy over everything
 	if (m.IsNull()) {
 		*this = oldAcc;

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -94,7 +94,7 @@ int16_t NeuralEvaluate(const Position& position) {
 
 // Accumulator updates ----------------------------------------------------------------------------
 
-void AccumulatorRepresentation::UpdateFrom(const Position& pos, const AccumulatorRepresentation& oldAcc,
+void AccumulatorRepresentation::UpdateFrom(const Board& b, const AccumulatorRepresentation& oldAcc,
 	const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece) {
 
 	// 1. For null-moves nothing changes, we just copy over everything
@@ -117,19 +117,19 @@ void AccumulatorRepresentation::UpdateFrom(const Position& pos, const Accumulato
 	if (keepWhite) {
 		White = oldAcc.White;
 		WhiteBucket = oldAcc.WhiteBucket;
-		WhiteKingSquare = pos.WhiteKingSquare();
+		WhiteKingSquare = LsbSquare(b.WhiteKingBits);  //pos.WhiteKingSquare();
 	}
 	else {
-		RefreshWhite(pos);
+		RefreshWhite(b);
 	}
 
 	if (keepBlack) {
 		Black = oldAcc.Black;
 		BlackBucket = oldAcc.BlackBucket;
-		BlackKingSquare = pos.BlackKingSquare();
+		BlackKingSquare = LsbSquare(b.BlackKingBits); //pos.BlackKingSquare();
 	}
 	else {
-		RefreshBlack(pos);
+		RefreshBlack(b);
 	}
 
 	// 3. Perform incremental updates

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -163,9 +163,11 @@ void AccumulatorRepresentation::UpdateIncrementally(const bool side, const Accum
 int16_t EvaluationState::Evaluate(const Position& pos) {
 
 	// For evaluating, we need to make sure the accumulator is up-to-date for both sides
+	// If we need a refresh, it's important to know, that the accumulator stack and the position stack are indexed differently
+	const int basePositionIndex = pos.States.size() - CurrentIndex - 1;
 
+	// Update white accumulators
 	if (!AccumulatorStack[CurrentIndex].WhiteGood) {
-
 		const int latestUpdated = [&] {
 			for (int i = CurrentIndex - 1; i >= 0; i--) {
 				if (AccumulatorStack[i].WhiteGood) return i;
@@ -175,7 +177,7 @@ int16_t EvaluationState::Evaluate(const Position& pos) {
 
 		for (int i = latestUpdated + 1; i <= CurrentIndex; i++) {
 			if (AccumulatorStack[i].movedPiece == Piece::WhiteKing && IsRefreshRequired(AccumulatorStack[i].move, Side::White)) {
-				AccumulatorStack[i].RefreshWhite(pos.States[i]);
+				AccumulatorStack[i].RefreshWhite(pos.States[basePositionIndex + i]);
 			}
 			else {
 				AccumulatorStack[i].UpdateIncrementally(Side::White, AccumulatorStack[i - 1]);
@@ -183,18 +185,18 @@ int16_t EvaluationState::Evaluate(const Position& pos) {
 		}
 	}
 
+	// Update black accumulators
 	if (!AccumulatorStack[CurrentIndex].BlackGood) {
-
 		const int latestUpdated = [&] {
 			for (int i = CurrentIndex - 1; i >= 0; i--) {
 				if (AccumulatorStack[i].BlackGood) return i;
 			}
 			assert(false);
-			}();
+		}();
 
 		for (int i = latestUpdated + 1; i <= CurrentIndex; i++) {
 			if (AccumulatorStack[i].movedPiece == Piece::BlackKing && IsRefreshRequired(AccumulatorStack[i].move, Side::Black)) {
-				AccumulatorStack[i].RefreshBlack(pos.States[i]);
+				AccumulatorStack[i].RefreshBlack(pos.States[basePositionIndex + i]);
 			}
 			else {
 				AccumulatorStack[i].UpdateIncrementally(Side::Black, AccumulatorStack[i - 1]);

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -94,93 +94,6 @@ int16_t NeuralEvaluate(const Position& position) {
 
 // Accumulator updates ----------------------------------------------------------------------------
 
-/*void AccumulatorRepresentation::UpdateFrom(const Board& b, const AccumulatorRepresentation& oldAcc,
-	const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece) {
-
-	WhiteGood = true;
-	BlackGood = true;
-
-	// 1. For null-moves nothing changes, we just copy over everything
-	if (m.IsNull()) {
-		*this = oldAcc;
-		return;
-	}
-
-	// 2. Determine if we require a refresh (which only can be needed when the king moves)
-
-	const bool side = ColorOfPiece(movedPiece) == PieceColor::White ? Side::White : Side::Black;
-	bool keepWhite = true;
-	bool keepBlack = true;
-
-	if (TypeOfPiece(movedPiece) == PieceType::King && IsRefreshRequired(m, side)) {
-		if (side == Side::White) keepWhite = false;
-		else keepBlack = false;
-	}
-
-	if (keepWhite) {
-		White = oldAcc.White;
-		WhiteBucket = oldAcc.WhiteBucket;
-		WhiteKingSquare = LsbSquare(b.WhiteKingBits);  //pos.WhiteKingSquare();
-	}
-	else {
-		RefreshWhite(b);
-	}
-
-	if (keepBlack) {
-		Black = oldAcc.Black;
-		BlackBucket = oldAcc.BlackBucket;
-		BlackKingSquare = LsbSquare(b.BlackKingBits); //pos.BlackKingSquare();
-	}
-	else {
-		RefreshBlack(b);
-	}
-
-	// 3. Perform incremental updates
-	
-	// (a) regular non-capture move
-	if (capturedPiece == Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed) {
-		SubAddFeature({ movedPiece, m.from }, { movedPiece, m.to }, keepWhite, keepBlack);;
-		return;
-	}
-
-	// (b) regular capture move
-	if (capturedPiece != Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed && !m.IsCastling()) {
-		SubSubAddFeature({ movedPiece, m.from }, { capturedPiece, m.to }, { movedPiece, m.to }, keepWhite, keepBlack);
-		return;
-	}
-
-	// (c) castling
-	if (m.IsCastling()) {
-		const bool side = ColorOfPiece(movedPiece) == PieceColor::White;
-		const bool shortCastle = m.flag == MoveFlag::ShortCastle;
-		const uint8_t rookPiece = side == Side::White ? Piece::WhiteRook : Piece::BlackRook;
-		const uint8_t newKingFile = shortCastle ? 6 : 2;
-		const uint8_t newRookFile = shortCastle ? 5 : 3;
-		const uint8_t newKingSquare = newKingFile + (side == Side::Black) * 56;
-		const uint8_t newRookSquare = newRookFile + (side == Side::Black) * 56;
-		SubAddFeature({ movedPiece, m.from }, { movedPiece, newKingSquare }, keepWhite, keepBlack);
-		SubAddFeature({ rookPiece, m.to }, { rookPiece, newRookSquare }, keepWhite, keepBlack);
-		return;
-	}
-
-	// (d) promotion - with optional capture
-	if (m.IsPromotion()) {
-		const uint8_t promotionPiece = m.GetPromotionPieceType() + (ColorOfPiece(movedPiece) == PieceColor::Black ? Piece::BlackPieceOffset : 0);
-		if (capturedPiece == Piece::None) SubAddFeature({ movedPiece, m.from }, { promotionPiece, m.to }, keepWhite, keepBlack);
-		else SubSubAddFeature({ movedPiece, m.from }, { capturedPiece, m.to }, { promotionPiece, m.to }, keepWhite, keepBlack);
-		return;
-	}
-
-	// (e) en passant
-	if (m.flag == MoveFlag::EnPassantPerformed) {
-		const uint8_t victimPiece = movedPiece == Piece::WhitePawn ? Piece::BlackPawn : Piece::WhitePawn;
-		const uint8_t victimSquare = movedPiece == Piece::WhitePawn ? (m.to - 8) : (m.to + 8);
-		SubSubAddFeature({ movedPiece, m.from }, { victimPiece, victimSquare }, { movedPiece, m.to }, keepWhite, keepBlack);
-		return;
-	}
-}*/
-
-
 void AccumulatorRepresentation::UpdateIncrementally(const bool side, const AccumulatorRepresentation& oldAcc,
 	const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece) {
 
@@ -211,17 +124,8 @@ void AccumulatorRepresentation::UpdateIncrementally(const bool side, const Accum
 	assert(capturedPiece == this->capturedPiece);
 	assert(m == this->move);
 
-	if (side == Side::White) {
-		this->White = oldAcc.White;
-		//this->WhiteBucket = oldAcc.WhiteBucket;
-		//this->WhiteKingSquare = oldAcc.WhiteKingSquare; // LOL HIGHLY TERRIBLE AND IT'S A LIE
-
-	}
-	else {
-		this->Black = oldAcc.Black;
-		//this->BlackBucket = oldAcc.BlackBucket;
-		//this->BlackKingSquare = oldAcc.BlackKingSquare; // LOL HIGHLY TERRIBLE AND IT'S A LIE
-	}
+	if (side == Side::White) this->White = oldAcc.White;
+	else this->Black = oldAcc.Black;
 
 	// (a) regular non-capture move
 	if (capturedPiece == Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed) {

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -191,7 +191,16 @@ void AccumulatorRepresentation::UpdateIncrementally(const Board& b, const bool s
 	
 	// 1. For null-moves nothing changes, we just copy over everything
 	if (m.IsNull()) {
-		*this = oldAcc;
+		if (side == Side::White) {
+			this->White = oldAcc.White;
+			this->WhiteKingSquare = oldAcc.WhiteKingSquare;
+			this->WhiteBucket = oldAcc.WhiteBucket;
+		}
+		else {
+			this->Black = oldAcc.Black;
+			this->BlackKingSquare = oldAcc.BlackKingSquare;
+			this->BlackBucket = oldAcc.BlackBucket;
+		}
 		this->move = NullMove;
 		this->movedPiece = Piece::None;
 		this->capturedPiece = Piece::None;

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -181,7 +181,7 @@ int16_t NeuralEvaluate(const Position& position) {
 }*/
 
 
-void AccumulatorRepresentation::UpdateIncrementally(const Board& b, const bool side, const AccumulatorRepresentation& oldAcc,
+void AccumulatorRepresentation::UpdateIncrementally(const bool side, const AccumulatorRepresentation& oldAcc,
 	const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece) {
 
 	assert(oldAcc.WhiteGood || side == Side::Black);
@@ -207,6 +207,22 @@ void AccumulatorRepresentation::UpdateIncrementally(const Board& b, const bool s
 		return;
 	}
 
+	assert(movedPiece == this->movedPiece);
+	assert(capturedPiece == this->capturedPiece);
+	assert(m == this->move);
+
+	if (side == Side::White) {
+		this->White = oldAcc.White;
+		//this->WhiteBucket = oldAcc.WhiteBucket;
+		//this->WhiteKingSquare = oldAcc.WhiteKingSquare; // LOL HIGHLY TERRIBLE AND IT'S A LIE
+
+	}
+	else {
+		this->Black = oldAcc.Black;
+		//this->BlackBucket = oldAcc.BlackBucket;
+		//this->BlackKingSquare = oldAcc.BlackKingSquare; // LOL HIGHLY TERRIBLE AND IT'S A LIE
+	}
+
 	// (a) regular non-capture move
 	if (capturedPiece == Piece::None && !m.IsPromotion() && m.flag != MoveFlag::EnPassantPerformed) {
 		SubAddFeature({ movedPiece, m.from }, { movedPiece, m.to }, side);
@@ -221,13 +237,13 @@ void AccumulatorRepresentation::UpdateIncrementally(const Board& b, const bool s
 
 	// (c) castling
 	if (m.IsCastling()) {
-		const bool side = ColorOfPiece(movedPiece) == PieceColor::White;
+		const bool castlingSide = ColorOfPiece(movedPiece) == PieceColor::White;
 		const bool shortCastle = m.flag == MoveFlag::ShortCastle;
-		const uint8_t rookPiece = side == Side::White ? Piece::WhiteRook : Piece::BlackRook;
+		const uint8_t rookPiece = castlingSide == Side::White ? Piece::WhiteRook : Piece::BlackRook;
 		const uint8_t newKingFile = shortCastle ? 6 : 2;
 		const uint8_t newRookFile = shortCastle ? 5 : 3;
-		const uint8_t newKingSquare = newKingFile + (side == Side::Black) * 56;
-		const uint8_t newRookSquare = newRookFile + (side == Side::Black) * 56;
+		const uint8_t newKingSquare = newKingFile + (castlingSide == Side::Black) * 56;
+		const uint8_t newRookSquare = newRookFile + (castlingSide == Side::Black) * 56;
 		SubAddFeature({ movedPiece, m.from }, { movedPiece, newKingSquare }, side);
 		SubAddFeature({ rookPiece, m.to }, { rookPiece, newRookSquare }, side);
 		return;

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -219,8 +219,12 @@ struct EvaluationState {
 		current.move = move;
 		current.movedPiece = movedPiece;
 		current.capturedPiece = capturedPiece;
-
-		//current.UpdateFrom(pos.States[CurrentIndex], AccumulatorStack[CurrentIndex - 1], move, movedPiece, capturedPiece);
+		current.BlackGood = false;
+		current.WhiteGood = false;
+		current.WhiteKingSquare = pos.WhiteKingSquare();
+		current.BlackKingSquare = pos.BlackKingSquare();
+		current.WhiteBucket = GetInputBucket(current.WhiteKingSquare, Side::White);
+		current.BlackBucket = GetInputBucket(current.BlackKingSquare, Side::Black);
 	}
 
 	inline void PopState() {

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -280,8 +280,8 @@ struct EvaluationState {
 		if (!AccumulatorStack[CurrentIndex].BlackGood) {
 
 			// Determine whether we can incrementally update this
-			const bool efficientlyUpdateable = false; [&] {
-				for (int i = CurrentIndex - 1; i >= 0; i--) {
+			const bool efficientlyUpdateable = [&] {
+				for (int i = CurrentIndex; i >= 0; i--) {
 					AccumulatorRepresentation& current = AccumulatorStack[i];
 					if (current.BlackGood) return true;
 					if (current.movedPiece == Piece::BlackKing && IsRefreshRequired(current.move, Side::Black)) return false;

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -201,8 +201,7 @@ struct alignas(64) AccumulatorRepresentation {
 		return { whiteFeatureIndex, blackFeatureIndex };
 	}
 
-	void UpdateIncrementally(const bool side, const AccumulatorRepresentation& oldAcc,
-		const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece);
+	void UpdateIncrementally(const bool side, const AccumulatorRepresentation& oldAcc);
 
 };
 
@@ -236,9 +235,7 @@ struct EvaluationState {
 
 	inline int16_t Evaluate(const Position& pos) {
 
-		AccumulatorRepresentation& c = AccumulatorStack[CurrentIndex];
-
-		// 1. Update all waiting
+		// For evaluating, we need to make sure the accumulator is up-to-date for both sides
 
 		if (!AccumulatorStack[CurrentIndex].WhiteGood) {
 
@@ -254,7 +251,7 @@ struct EvaluationState {
 					AccumulatorStack[i].RefreshWhite(pos.States[i]);
 				}
 				else {
-					AccumulatorStack[i].UpdateIncrementally(Side::White, AccumulatorStack[i - 1], AccumulatorStack[i].move, AccumulatorStack[i].movedPiece, AccumulatorStack[i].capturedPiece);
+					AccumulatorStack[i].UpdateIncrementally(Side::White, AccumulatorStack[i - 1]);
 				}
 			}
 		}
@@ -273,13 +270,10 @@ struct EvaluationState {
 					AccumulatorStack[i].RefreshBlack(pos.States[i]);
 				}
 				else {
-					AccumulatorStack[i].UpdateIncrementally(Side::Black, AccumulatorStack[i - 1], AccumulatorStack[i].move, AccumulatorStack[i].movedPiece, AccumulatorStack[i].capturedPiece);
+					AccumulatorStack[i].UpdateIncrementally(Side::Black, AccumulatorStack[i - 1]);
 				}
 			}
 		}
-
-		assert(AccumulatorStack[CurrentIndex].WhiteGood);
-		assert(AccumulatorStack[CurrentIndex].BlackGood);
 
 		//int good = NeuralEvaluate(pos);
 		//int bad = NeuralEvaluate(pos, AccumulatorStack[CurrentIndex]);

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -233,52 +233,5 @@ struct EvaluationState {
 		AccumulatorStack[0].RefreshBoth(pos);
 	}
 
-	inline int16_t Evaluate(const Position& pos) {
-
-		// For evaluating, we need to make sure the accumulator is up-to-date for both sides
-
-		if (!AccumulatorStack[CurrentIndex].WhiteGood) {
-
-			const int latestUpdated = [&] {
-				for (int i = CurrentIndex - 1; i >= 0; i--) {
-					if (AccumulatorStack[i].WhiteGood) return i;
-				}
-				assert(false);
-			}();
-
-			for (int i = latestUpdated + 1; i <= CurrentIndex; i++) {
-				if (AccumulatorStack[i].movedPiece == Piece::WhiteKing && IsRefreshRequired(AccumulatorStack[i].move, Side::White)) {
-					AccumulatorStack[i].RefreshWhite(pos.States[i]);
-				}
-				else {
-					AccumulatorStack[i].UpdateIncrementally(Side::White, AccumulatorStack[i - 1]);
-				}
-			}
-		}
-
-		if (!AccumulatorStack[CurrentIndex].BlackGood) {
-
-			const int latestUpdated = [&] {
-				for (int i = CurrentIndex - 1; i >= 0; i--) {
-					if (AccumulatorStack[i].BlackGood) return i;
-				}
-				assert(false);
-			}();
-
-			for (int i = latestUpdated + 1; i <= CurrentIndex; i++) {
-				if (AccumulatorStack[i].movedPiece == Piece::BlackKing && IsRefreshRequired(AccumulatorStack[i].move, Side::Black)) {
-					AccumulatorStack[i].RefreshBlack(pos.States[i]);
-				}
-				else {
-					AccumulatorStack[i].UpdateIncrementally(Side::Black, AccumulatorStack[i - 1]);
-				}
-			}
-		}
-
-		//int good = NeuralEvaluate(pos);
-		//int bad = NeuralEvaluate(pos, AccumulatorStack[CurrentIndex]);
-		//assert(good == bad);
-
-		return NeuralEvaluate(pos, AccumulatorStack[CurrentIndex]);
-	}
+	int16_t Evaluate(const Position& pos);
 };

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -188,7 +188,7 @@ struct alignas(64) AccumulatorRepresentation {
 		else BlackBucket = bucket;
 	}
 
-	inline std::pair<int, int> FeatureIndexes(const uint8_t piece, const uint8_t sq) {
+	inline std::pair<int, int> FeatureIndexes(const uint8_t piece, const uint8_t sq) const {
 		const uint8_t pieceColor = ColorOfPiece(piece);
 		const uint8_t pieceType = TypeOfPiece(piece);
 		constexpr int colorOffset = 64 * 6;
@@ -206,7 +206,7 @@ struct alignas(64) AccumulatorRepresentation {
 };
 
 struct EvaluationState {
-	std::array<AccumulatorRepresentation, MaxDepth> AccumulatorStack;
+	std::array<AccumulatorRepresentation, MaxDepth + 1> AccumulatorStack;
 	int CurrentIndex;
 
 	inline void PushState(const Position& pos, const Move move, const uint8_t movedPiece, const uint8_t capturedPiece) {

--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -272,8 +272,28 @@ struct EvaluationState {
 				}
 			}
 			else {
+
+				const int latestUpdated = [&] {
+					for (int i = CurrentIndex - 1; i >= 0; i--) {
+						if (AccumulatorStack[i].WhiteGood) return i;
+					}
+					assert(false);
+					}();
+				for (int i = latestUpdated + 1; i <= CurrentIndex; i++) {
+					if (AccumulatorStack[i].movedPiece == Piece::WhiteKing && IsRefreshRequired(AccumulatorStack[i].move, Side::White)) {
+						AccumulatorStack[i].RefreshWhite(pos.States[i]);
+					}
+					else {
+						AccumulatorStack[i].UpdateIncrementally(Side::White, AccumulatorStack[i - 1], AccumulatorStack[i].move, AccumulatorStack[i].movedPiece, AccumulatorStack[i].capturedPiece);
+					}
+				}
+
+
+
+
+
 				// Recalculate only this
-				AccumulatorStack[CurrentIndex].RefreshWhite(pos.CurrentState());
+				//AccumulatorStack[CurrentIndex].RefreshWhite(pos.CurrentState());
 			}
 		}
 
@@ -304,8 +324,20 @@ struct EvaluationState {
 				}
 			}
 			else {
-				// Recalculate only this
-				AccumulatorStack[CurrentIndex].RefreshBlack(pos.CurrentState());
+				const int latestUpdated = [&] {
+					for (int i = CurrentIndex - 1; i >= 0; i--) {
+						if (AccumulatorStack[i].BlackGood) return i;
+					}
+					assert(false);
+					}();
+				for (int i = latestUpdated + 1; i <= CurrentIndex; i++) {
+					if (AccumulatorStack[i].movedPiece == Piece::BlackKing && IsRefreshRequired(AccumulatorStack[i].move, Side::Black)) {
+						AccumulatorStack[i].RefreshBlack(pos.States[i]);
+					}
+					else {
+						AccumulatorStack[i].UpdateIncrementally(Side::Black, AccumulatorStack[i - 1], AccumulatorStack[i].move, AccumulatorStack[i].movedPiece, AccumulatorStack[i].capturedPiece);
+					}
+				}
 			}
 		}
 

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -32,7 +32,7 @@ public:
 	Histories History;
 	MultiArray<Move, MaxDepth + 1, MaxDepth + 1> PvTable;
 	std::array<int, MaxDepth + 1> PvLength;
-	std::array<AccumulatorRepresentation, MaxDepth + 1> Accumulators;
+	EvaluationState EvalState;
 	MultiArray<uint64_t, 64, 64> RootNodeCounts;
 
 	// PV table
@@ -135,7 +135,7 @@ private:
 	int SearchRecursive(ThreadData& t, int depth, const int level, int alpha, int beta, const bool pvNode, const bool cutNode);
 	int SearchQuiescence(ThreadData& t, const int level, int alpha, int beta, const bool pvNode);
 
-	int16_t Evaluate(const ThreadData& t, const Position& position, const int level);
+	int16_t Evaluate(ThreadData& t, const Position& position, const int level);
 	uint64_t PerftRecursive(Position& position, const int depth, const int originalDepth, const PerftType type) const;
 	SearchConstraints CalculateConstraints(const SearchParams params, const bool turn) const;
 	bool ShouldAbort(const ThreadData& t);
@@ -145,10 +145,6 @@ private:
 	void OrderMovesQ(const ThreadData& t, const Position& position, MoveList& ml, const int level, const Move& ttMove);
 	int CalculateOrderScore(const ThreadData& t, const Position& position, const Move& m, const int level, const Move& ttMove,
 		const bool losingCapture, const bool useMoveStack) const;
-
-	// NNUE
-	void SetupAccumulators(ThreadData& t);
-	void UpdateAccumulators(ThreadData& t, const Move& m, const uint8_t movedPiece, const uint8_t capturedPiece, const int level);
 
 	
 	SearchConstraints Constraints;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.66";
+constexpr std::string_view Version = "dev 1.1.67";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This patch clearly loses at singlethreaded STC:
```
Elo   | -9.04 +- 4.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -2.27 (-2.25, 2.89) [-3.50, 0.00]
Games | N: 4612 W: 929 L: 1049 D: 2634
Penta | [21, 531, 1307, 441, 6]
https://zzzzz151.pythonanywhere.com/test/1681/
```

However, it gains at 8 threads VSTC:
```
Elo   | 5.65 +- 3.31 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.50]
Games | N: 10270 W: 2241 L: 2074 D: 5955
Penta | [16, 1091, 2760, 1246, 22]
https://zzzzz151.pythonanywhere.com/test/1682/
```

Some testing locally indicated that the regression in speed is most likely caused by the current prefetch logic becoming much less efficient, but this can be improved later. Also, the new patch crashed twice out of these ~15k games, this is probably due to some rare out-of-bounds indexing, and should be fixed now.

Renegade dev 1.1.67
Bench: 2816679