### PR TITLE
Prefetch transposition table earlier & based on a speculative hash

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -557,9 +557,10 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		const uint8_t movedPiece = position.GetPieceAt(m.from);
 		const uint8_t capturedPiece = position.GetPieceAt(m.to);
 		const uint64_t nodesBefore = t.Nodes;
+		TranspositionTable.Prefetch(position.ApproximateHashAfterMove(m));
 
 		position.PushMove(m);
-		TranspositionTable.Prefetch(position.Hash());
+		//TranspositionTable.Prefetch(position.Hash());
 		t.Nodes += 1;
 		int score = NoEval;
 		t.EvalState.PushState(position, m, movedPiece, capturedPiece);
@@ -735,8 +736,9 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 
 		const uint8_t movedPiece = position.GetPieceAt(m.from);
 		const uint8_t capturedPiece = position.GetPieceAt(m.to);
+		TranspositionTable.Prefetch(position.ApproximateHashAfterMove(m));
 		position.PushMove(m);
-		TranspositionTable.Prefetch(position.Hash());
+		//TranspositionTable.Prefetch(position.Hash());
 		t.EvalState.PushState(position, m, movedPiece, capturedPiece);
 		const int score = -SearchQuiescence(t, level + 1, -beta, -alpha, pvNode);
 		position.PopMove();

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -557,10 +557,9 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		const uint8_t movedPiece = position.GetPieceAt(m.from);
 		const uint8_t capturedPiece = position.GetPieceAt(m.to);
 		const uint64_t nodesBefore = t.Nodes;
-		TranspositionTable.Prefetch(position.ApproximateHashAfterMove(m));
 
+		TranspositionTable.Prefetch(position.ApproximateHashAfterMove(m));
 		position.PushMove(m);
-		//TranspositionTable.Prefetch(position.Hash());
 		t.Nodes += 1;
 		int score = NoEval;
 		t.EvalState.PushState(position, m, movedPiece, capturedPiece);
@@ -738,7 +737,6 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 		const uint8_t capturedPiece = position.GetPieceAt(m.to);
 		TranspositionTable.Prefetch(position.ApproximateHashAfterMove(m));
 		position.PushMove(m);
-		//TranspositionTable.Prefetch(position.Hash());
 		t.EvalState.PushState(position, m, movedPiece, capturedPiece);
 		const int score = -SearchQuiescence(t, level + 1, -beta, -alpha, pvNode);
 		position.PopMove();

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.67";
+constexpr std::string_view Version = "dev 1.1.68";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Recovering some speed lost from #72 
```
Elo   | 5.51 +- 3.28 (95%)
SPRT  | 3.0+0.03s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.50]
Games | N: 10904 W: 2616 L: 2443 D: 5845
Penta | [54, 1064, 3056, 1211, 67]
https://zzzzz151.pythonanywhere.com/test/1688/
```

Renegade dev 1.1.68
Bench: 2816679