### PR TITLE
Use the mean of raw and static evaluation in corrhist updates

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -142,6 +142,6 @@ int16_t Histories::ApplyCorrection(const Position& position, const int16_t rawEv
 		return FollowUpCorrectionHistory[prev2.piece][prev2.move.to][prev1.piece][prev1.move.to] / 256;
 	}();
 
-	const int correctedEval = rawEval + (materialCorrection + pawnCorrection + lastMoveCorrection) * 2 / 3;
+	const int correctedEval = rawEval + (materialCorrection + pawnCorrection + lastMoveCorrection);
 	return std::clamp(correctedEval, -MateThreshold + 1, MateThreshold - 1);
 }

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -671,7 +671,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 				   || (scoreType == ScoreType::UpperBound && bestScore < staticEval)
 				   || (scoreType == ScoreType::LowerBound && bestScore > staticEval);
 		}();
-		if (updateCorrection) t.History.UpdateCorrection(position, rawEval, bestScore, depth);
+		if (updateCorrection) t.History.UpdateCorrection(position, (rawEval + staticEval) / 2, bestScore, depth);
 	}
 
 	// Store node search results into the transposition table

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.68";
+constexpr std::string_view Version = "dev 1.1.69";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Combination of our 2 ideas:

1. Using average of static evaluation and raw evaluation to update correction history.
2. It is useful to allow bigger correction when using static evaluation for correction history updates (and apparently it is useful even when using both evaluations for update). 

Both ideas were neutral on their own, but together they gain elo:

```
Elo   | 3.63 +- 2.54 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.50]
Games | N: 18744 W: 4155 L: 3959 D: 10630
Penta | [62, 2106, 4838, 2306, 60]
```

Renegade dev 1.1.69
Bench: 2804167