### PR TITLE
Simplify the history formula and its application

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -50,8 +50,7 @@ void Histories::UpdateHistory(const Position& position, const Move& m, const uin
 	const bool side = ColorOfPiece(piece) == PieceColor::White;
 	const bool fromSquareAttacked = position.IsSquareThreatened(m.from);
 	const bool toSquareAttacked = position.IsSquareThreatened(m.to);
-	const int16_t quietHistoryDelta = delta + ((delta > 0) ? 300 : -300);
-	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], quietHistoryDelta);
+	UpdateHistoryValue(QuietHistory[piece][m.to][fromSquareAttacked][toSquareAttacked], delta);
 
 	// Continuation history
 	for (const int ply : { 1, 2, 4 }) {

--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -22,8 +22,8 @@ std::unique_ptr<NetworkRepresentation> ExternalNetwork;
 // Evaluating the position ------------------------------------------------------------------------
 
 int16_t NeuralEvaluate(const Position& position, const AccumulatorRepresentation& acc) {
-	assert(AccumulatorStack[CurrentIndex].WhiteGood);
-	assert(AccumulatorStack[CurrentIndex].BlackGood);
+	assert(acc.WhiteGood);
+	assert(acc.BlackGood);
 
 	const bool turn = position.Turn();
 	const std::array<int16_t, HiddenSize>& hiddenFriendly = (turn == Side::White) ? acc.White : acc.Black;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.69";
+constexpr std::string_view Version = "dev 1.1.70";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Further simplifies history formulas after #71, and enables history updates at depth 1.

```
Elo   | 2.27 +- 2.73 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.50, 0.00]
Games | N: 16074 W: 3563 L: 3458 D: 9053
Penta | [42, 1847, 4163, 1934, 51]
https://zzzzz151.pythonanywhere.com/test/1717/
```

Renegade dev 1.1.70
Bench: 2670570