### PR TITLE
Simplify singular extension guard

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -212,7 +212,6 @@ void Search::SearchMoves(ThreadData& t) {
 	std::fill(t.ExcludedMoves.begin(), t.ExcludedMoves.end(), EmptyMove);
 	std::fill(t.SuperSingular.begin(), t.SuperSingular.end(), false);
 	std::fill(t.CutoffCount.begin(), t.CutoffCount.end(), 0);
-	std::fill(t.DoubleExtensions.begin(), t.DoubleExtensions.end(), 0);
 	std::memset(&t.RootNodeCounts, 0, sizeof(t.RootNodeCounts));
 	t.History.ClearKillerAndCounterMoves();
 	t.EvalState.Reset(t.CurrentPosition);
@@ -487,7 +486,6 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		// Resetting killers and fail-high cutoff counts
 		if (level + 2 < MaxDepth) t.History.ResetKillerForPly(level + 2);
 		if (level + 1 < MaxDepth) t.CutoffCount[level + 1] = 0;
-		if (level > 0) t.DoubleExtensions[level] = t.DoubleExtensions[level - 1];
 	}
 	MovePicker movePicker(t.MoveListStack[level]);
 
@@ -532,7 +530,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Singular extensions
 		int extension = 0;
-		if (singularCandidate && m == ttMove) {
+		if (singularCandidate && m == ttMove && level < t.Depth * 2) {
 			const int singularMargin = depth * 2;
 			const int singularBeta = std::max(ttEval - singularMargin, -MateEval);
 			const int singularDepth = (depth - 1) / 2;
@@ -542,8 +540,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 				
 			if (singularScore < singularBeta) {
 				// Successful extension
-				const bool doubleExtend = (!pvNode && (singularScore < singularBeta - 30) && (t.DoubleExtensions[level] < 6)) || t.SuperSingular[level];
-				if (doubleExtend) t.DoubleExtensions[level] += 1;
+				const bool doubleExtend = (!pvNode && (singularScore < singularBeta - 30)) || t.SuperSingular[level];
 				extension = 1 + doubleExtend;
 			}
 			else {

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -545,7 +545,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			}
 			else {
 				// Extension check failed
-				if (!pvNode && (singularBeta >= beta)) return singularBeta; //
+				if (!pvNode && (singularBeta >= beta)) return singularBeta;
 				else if (cutNode) extension = -1;
 			}
 		}

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -46,7 +46,6 @@ public:
 	std::array<int, MaxDepth> StaticEvalStack;
 	std::array<int, MaxDepth> EvalStack;
 	std::array<int, MaxDepth> CutoffCount;
-	std::array<int, MaxDepth> DoubleExtensions;
 	std::array<Move, MaxDepth> ExcludedMoves;
 	std::array<bool, MaxDepth> SuperSingular;
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.71";
+constexpr std::string_view Version = "dev 1.1.72";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 0.25 +- 1.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.50, 0.00]
Games | N: 44118 W: 9709 L: 9677 D: 24732
Penta | [87, 4540, 12779, 4560, 93]
https://zzzzz151.pythonanywhere.com/test/1743/
```

Renegade dev 1.1.72
Bench: 2792538