### PR TITLE
Simplify away reducing less when in check

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -566,7 +566,6 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			
 			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 1;
-			//if (inCheck) reduction -= 1;
 			if (t.CutoffCount[level] < 4) reduction -= 1;
 			if (std::abs(order) < 80000) reduction -= std::clamp(order / 8192, -2, 2);
 			if (cutNode) reduction += 1;

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -566,7 +566,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			
 			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 1;
-			if (inCheck) reduction -= 1;
+			//if (inCheck) reduction -= 1;
 			if (t.CutoffCount[level] < 4) reduction -= 1;
 			if (std::abs(order) < 80000) reduction -= std::clamp(order / 8192, -2, 2);
 			if (cutNode) reduction += 1;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.78";
+constexpr std::string_view Version = "dev 1.1.79";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.34 +- 2.77 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.50, 0.00]
Games | N: 15740 W: 3490 L: 3384 D: 8866
Penta | [48, 1802, 4067, 1902, 51]
https://zzzzz151.pythonanywhere.com/test/1797/
```

Renegade dev 1.1.79
Bench: 2843759