### PR TITLE
Enable singular extensions at depth 8

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -401,7 +401,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		}
 	}
 
-	const bool singularCandidate = found && !rootNode && !singularSearch && (depth > 8)
+	const bool singularCandidate = found && !rootNode && !singularSearch && (depth > 7)
 		&& (ttEntry.depth >= depth - 3) && (ttEntry.scoreType != ScoreType::UpperBound) && !IsMateScore(ttEval);
 	const bool ttPV = pvNode || ttEntry.ttPv;
 	

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.79";
+constexpr std::string_view Version = "dev 1.1.80";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.06 +- 1.66 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.50]
Games | N: 43962 W: 9825 L: 9564 D: 24573
Penta | [132, 5118, 11211, 5397, 123]
https://zzzzz151.pythonanywhere.com/test/1832/
```

Renegade dev 1.1.80
Bench: 2950436