### PR TITLE
Make the history-dependent reduction term less drastic

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -567,7 +567,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 1;
 			if (t.CutoffCount[level] < 4) reduction -= 1;
-			if (std::abs(order) < 80000) reduction -= std::clamp(order / 8192, -2, 2);
+			if (std::abs(order) < 80000) reduction -= std::clamp(order / 16384, -2, 2);
 			if (cutNode) reduction += 1;
 			reduction = std::max(reduction, 0);
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.80";
+constexpr std::string_view Version = "dev 1.1.81";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 4.14 +- 2.76 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.50]
Games | N: 15516 W: 3462 L: 3277 D: 8777
Penta | [43, 1710, 4074, 1881, 50]
https://zzzzz151.pythonanywhere.com/test/1856/
```

Renegade dev 1.1.81
Bench: 3057150