### PR TITLE
Organize transposition table entries into clusters

### DIFF
--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -6,26 +6,48 @@ Transpositions::Transpositions() {
 
 void Transpositions::Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level, const bool ttPv) {
 
-	//assert(std::abs(score) > MateEval);
+	assert(std::abs(score) > MateEval);
 	assert(HashMask != 0);
 	if (std::abs(score) > MateEval) return;
 
 	const uint64_t key = hash & HashMask;
 	const uint16_t quality = Age * 2 + depth;
 	const uint32_t storedHash = static_cast<uint32_t>((hash & 0xFFFFFFFF00000000) >> 32);
+	const TranspositionCluster& cluster = Table[key];
 
-	if (quality >= Table[key].quality) {
-		Table[key].depth = depth;
-		if (Table[key].hash != storedHash || !bestMove.IsNull()) {
-			Table[key].packedMove = bestMove.Pack();
+	// Find the slot to use
+	const int candidateSlot = [&] {
+		int currentWorst = -1, currentWorstQuality = 1000000;
+		for (int i = 0; i < cluster.Entries.size(); i++) {
+			if (cluster.Entries[i].scoreType == ScoreType::Invalid) return i;
+			if (cluster.Entries[i].hash == storedHash) return i;
+
+			const int quality = cluster.Entries[i].quality;
+			if (quality < currentWorstQuality) {
+				currentWorst = i;
+				currentWorstQuality = quality;
+			};
+		};
+		assert(currentWorst != -1);
+		return currentWorst;
+	}();
+
+	TranspositionEntry& candidateEntry = Table[key].Entries[candidateSlot];
+
+	// Check if replaceable
+
+	if (quality >= candidateEntry.quality) {
+		candidateEntry.depth = depth;
+		if (candidateEntry.hash != storedHash || !bestMove.IsNull()) {
+			candidateEntry.packedMove = bestMove.Pack();
 		}
-		Table[key].scoreType = scoreType;
-		Table[key].hash = storedHash;
-		Table[key].quality = quality;
-		Table[key].rawEval = rawEval;
-		Table[key].ttPv = ttPv;
+		candidateEntry.scoreType = scoreType;
+		candidateEntry.hash = storedHash;
+		candidateEntry.quality = quality;
+		candidateEntry.rawEval = rawEval;
+		candidateEntry.ttPv = ttPv;
 
-		Table[key].score = [&] {
+		candidateEntry.score = [&] {
 			if (IsWinningMateScore(score)) return static_cast<int16_t>(score + level);
 			if (IsLosingMateScore(score)) return static_cast<int16_t>(score - level);
 			return score;
@@ -33,16 +55,18 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 	}
 }
 
-bool Transpositions::Probe(const uint64_t& hash, TranspositionEntry& entry, const int level) const {
+bool Transpositions::Probe(const uint64_t hash, TranspositionEntry& returned, const int level) const {
 	assert(HashMask != 0);
-	const uint64_t key = hash & HashMask;
+	const uint64_t key = GetClusterIndex(hash);
 	const uint32_t storedHash = static_cast<uint32_t>((hash & 0xFFFFFFFF00000000) >> 32);
+	const TranspositionCluster& cluster = Table[key];
 
-	if (Table[key].hash == storedHash) {
-		entry = Table[key];
+	for (const TranspositionEntry& entry : cluster.Entries) {
+		if (entry.hash != storedHash) continue;
 
-		entry.score = [&] {
-			const int32_t score = Table[key].score;
+		returned = entry;
+		returned.score = [&] {
+			const int32_t score = entry.score;
 			if (IsLosingMateScore(score)) return score + level;
 			if (IsWinningMateScore(score)) return score - level;
 			return score;
@@ -54,7 +78,7 @@ bool Transpositions::Probe(const uint64_t& hash, TranspositionEntry& entry, cons
 
 void Transpositions::Prefetch(const uint64_t hash) const {
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-	const uint64_t key = hash & HashMask;
+	const uint64_t key = GetClusterIndex(hash);
 	__builtin_prefetch(&Table[key]);
 #endif
 }
@@ -64,29 +88,28 @@ void Transpositions::IncreaseAge() {
 }
 
 void Transpositions::SetSize(const int megabytes) {
-	assert(megabytes != 0);
-	const uint64_t theoreticalEntryCount = static_cast<uint64_t>(megabytes) * 1024 * 1024 / sizeof(TranspositionEntry);
-	int bits = 0;
-	while ((1ull << bits) <= theoreticalEntryCount) bits += 1;
-	bits -= 1;
-	HashMask = (1ull << bits) - 1;
+	assert(megabytes > 0);
+	const uint64_t theoreticalClusterCount = static_cast<uint64_t>(megabytes) * 1024 * 1024 / sizeof(TranspositionCluster);
+	const uint64_t actualClusterCount = std::bit_floor(theoreticalClusterCount);
+	HashMask = actualClusterCount - 1;
 	Clear();
 }
 
 void Transpositions::Clear() {
 	Table.clear();
 	Table.reserve(HashMask + 1);
-	for (uint64_t i = 0; i < HashMask + 1; i++) Table.push_back(TranspositionEntry());
-	Table.shrink_to_fit();
+	for (uint64_t i = 0; i < HashMask + 1; i++) Table.push_back(TranspositionCluster());
+	Table.shrink_to_fit(); // I don't think that's needed
 	Age = 0;
 }
 
 int Transpositions::GetHashfull() const {
-	// Approximate by checking the usage of the first 1000 entries
+	// Approximate by checking the usage of the first 1000 clusters
 	int hashfull = 0;
 	for (int i = 0; i < 1000; i++) {
-		const TranspositionEntry& entry = Table[i];
-		if (Table[i].quality >= Age * 2) hashfull += 1;
+		for (const TranspositionEntry& entry : Table[i].Entries) {
+			if (entry.quality >= Age * 2) hashfull += 1;
+		}
 	}
-	return hashfull;
+	return hashfull / 4;
 }

--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -34,7 +34,7 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 
 	TranspositionEntry& candidateEntry = Table[key].Entries[candidateSlot];
 
-	// Check if replaceable
+	// Check if replaceable ...
 
 	if (quality >= candidateEntry.quality) {
 		candidateEntry.depth = depth;

--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -35,8 +35,14 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 	TranspositionEntry& candidateEntry = Table[key].Entries[candidateSlot];
 
 	// Check if replaceable ...
+	const bool replaceable = [&] {
+		if (storedHash != candidateEntry.hash) return true;
+		if (scoreType == ScoreType::Exact) return true;
+		return quality >= candidateEntry.quality;
+	}();
 
-	if (quality >= candidateEntry.quality) {
+	// Update entry within the cluster
+	if (replaceable) {
 		candidateEntry.depth = depth;
 		if (candidateEntry.hash != storedHash || !bestMove.IsNull()) {
 			candidateEntry.packedMove = bestMove.Pack();

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -30,7 +30,7 @@ struct TranspositionEntry {
 	}
 };
 struct alignas(64) TranspositionCluster {
-	std::array<TranspositionEntry, 4> Entries;
+	std::array<TranspositionEntry, 4> Entries{};
 };
 
 static_assert(sizeof(TranspositionEntry) == 16);

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -30,7 +30,7 @@ struct TranspositionEntry {
 	}
 };
 struct alignas(64) TranspositionCluster {
-	std::array<TranspositionEntry, 4> Entries{};
+	std::array<TranspositionEntry, 4> entries{};
 };
 
 static_assert(sizeof(TranspositionEntry) == 16);
@@ -55,6 +55,10 @@ private:
 
 	inline uint64_t GetClusterIndex(const uint64_t hash) const {
 		return hash & HashMask;
+	}
+
+	inline uint32_t GetStoredHash(const uint64_t hash) const {
+		return static_cast<uint32_t>((hash & 0xFFFFFFFF00000000) >> 32);
 	}
 };
 

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -6,16 +6,17 @@
 #include <memory>
 
 namespace ScoreType {
-	constexpr int Exact = 0;
-	constexpr int UpperBound = 1; // Alpha (fail-low)
-	constexpr int LowerBound = 2; // Beta (fail-high)
+	constexpr int Invalid = 0;
+	constexpr int Exact = 1;
+	constexpr int UpperBound = 2; // Alpha (fail-low)
+	constexpr int LowerBound = 3; // Beta (fail-high)
 };
 
 struct TranspositionEntry {
 	uint32_t hash = 0;
 	int16_t score = 0;
 	int16_t rawEval = 0;
-	uint16_t quality = 0;
+	uint16_t quality = ScoreType::Invalid;
 	uint8_t depth = 0;
 	uint8_t scoreType = 0;
 	uint16_t packedMove = 0;
@@ -28,14 +29,19 @@ struct TranspositionEntry {
 			|| (scoreType == ScoreType::LowerBound && score >= beta);
 	}
 };
+struct alignas(64) TranspositionCluster {
+	std::array<TranspositionEntry, 4> Entries;
+};
+
 static_assert(sizeof(TranspositionEntry) == 16);
+static_assert(sizeof(TranspositionCluster) == 64);
 
 class Transpositions
 {
 public:
 	Transpositions();
 	void Store(const uint64_t hash, const int depth, const int16_t score, const int scoreType, const int16_t rawEval, const Move& bestMove, const int level, const bool ttPv);
-	bool Probe(const uint64_t& hash, TranspositionEntry& entry, const int level) const;
+	bool Probe(const uint64_t hash, TranspositionEntry& entry, const int level) const;
 	void Prefetch(const uint64_t hash) const;
 	void IncreaseAge();
 	void SetSize(const int megabytes);
@@ -43,8 +49,12 @@ public:
 	int GetHashfull() const;
 
 private:
-	std::vector<TranspositionEntry> Table;
+	std::vector<TranspositionCluster> Table;
 	uint64_t HashMask;
 	uint16_t Age;
+
+	inline uint64_t GetClusterIndex(const uint64_t hash) const {
+		return hash & HashMask;
+	}
 };
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.81";
+constexpr std::string_view Version = "dev 1.1.82";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Organize entries in the transposition table into clusters of 4, with each being 16 bytes.

Regular STC:
```
Elo   | 8.92 +- 4.34 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.50]
Games | N: 6430 W: 1512 L: 1347 D: 3571
Penta | [14, 695, 1639, 846, 21]
https://zzzzz151.pythonanywhere.com/test/1872/
```

Hash constrained STC:
```
Elo   | 13.64 +- 5.45 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=1MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.50]
Games | N: 4052 W: 982 L: 823 D: 2247
Penta | [4, 423, 1024, 560, 15]
https://zzzzz151.pythonanywhere.com/test/1871/
```

Hash constrained LTC:
```
Elo   | 9.72 +- 4.51 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.50]
Games | N: 5614 W: 1279 L: 1122 D: 3213
Penta | [3, 600, 1447, 751, 6]
https://zzzzz151.pythonanywhere.com/test/1880/
```

Unfinished regular LTC:
```
Elo   | 2.62 +- 4.20 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 0.66 (-2.25, 2.89) [0.00, 3.50]
Games | N: 6508 W: 1417 L: 1368 D: 3723
Penta | [6, 752, 1692, 795, 9]
https://zzzzz151.pythonanywhere.com/test/1873/
```

Renegade dev 1.1.82
Bench: 3660392