### PR TITLE
Reverse futility pruning: return the mean of eval and beta

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -442,7 +442,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		// Reverse futility pruning
 		const int rfpMargin = depth * 90 - improving * 90;
 		if (depth <= 7 && !IsMateScore(beta)) {
-			if (eval - rfpMargin > beta) return eval;
+			if (eval - rfpMargin > beta) return (eval + beta) / 2;
 		}
 
 		// Null-move pruning

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.82";
+constexpr std::string_view Version = "dev 1.1.83";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 6.65 +- 3.44 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9986 W: 2276 L: 2085 D: 5625
Penta | [25, 1074, 2607, 1259, 28]
https://zzzzz151.pythonanywhere.com/test/1883/
```

Renegade dev 1.1.83
Bench: 3330333