### PR TITLE
Re-search deeper in LMR when the score is unexpectedly high

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -498,7 +498,6 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	int failLowCount = 0;
 	Move bestMove = NullMove;
 	int bestScore = NegativeInfinity;
-	bool deepen = false;
 
 	StaticVector<Move, MaxMoveCount> quietsTried;
 	StaticVector<Move, MaxMoveCount> capturesTried;
@@ -564,6 +563,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		t.Nodes += 1;
 		int score = NoEval;
 		t.EvalState.PushState(position, m, movedPiece, capturedPiece);
+		bool deepen = false;
 
 		
 		// Late-move reductions & principal variation search
@@ -580,7 +580,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			score = -SearchRecursive(t, reducedDepth, level + 1, -alpha - 1, -alpha, false, true);
 
 			if (score > alpha && reducedDepth < depth - 1) {
-				if (!deepen) deepen = score > (bestScore + 50 + (depth - 1) * 5);
+				deepen = score > (bestScore + 50 + (depth - 1) * 5);
 				score = -SearchRecursive(t, depth - 1 + deepen, level + 1, -alpha - 1, -alpha, false, !cutNode);
 			}
 		}
@@ -589,7 +589,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		}
 
 		if (pvNode && (legalMoveCount == 1 || score > alpha)) {
-			score = -SearchRecursive(t, depth - 1 + extension, level + 1, -beta, -alpha, true, false);
+			score = -SearchRecursive(t, depth - 1 + extension + deepen, level + 1, -beta, -alpha, true, false);
 		}
 
 		position.PopMove();

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -498,6 +498,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	int failLowCount = 0;
 	Move bestMove = NullMove;
 	int bestScore = NegativeInfinity;
+	bool deepen = false;
 
 	StaticVector<Move, MaxMoveCount> quietsTried;
 	StaticVector<Move, MaxMoveCount> capturesTried;
@@ -579,7 +580,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			score = -SearchRecursive(t, reducedDepth, level + 1, -alpha - 1, -alpha, false, true);
 
 			if (score > alpha && reducedDepth < depth - 1) {
-				score = -SearchRecursive(t, depth - 1, level + 1, -alpha - 1, -alpha, false, !cutNode);
+				if (!deepen) deepen = score > (bestScore + 50 + (depth - 1) * 5);
+				score = -SearchRecursive(t, depth - 1 + deepen, level + 1, -alpha - 1, -alpha, false, !cutNode);
 			}
 		}
 		else if (!pvNode || legalMoveCount > 1) {

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.84";
+constexpr std::string_view Version = "dev 1.1.85";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.79 +- 2.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19600 W: 4427 L: 4213 D: 10960
Penta | [50, 2216, 5052, 2434, 48]
https://zzzzz151.pythonanywhere.com/test/1910/
```

Renegade dev 1.1.85
Bench: 3158670