### PR TITLE
Adjust good capture history threshold

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -933,7 +933,7 @@ void Search::OrderMoves(const ThreadData& t, const Position& position, MoveList&
 		const bool losingCapture = [&] {
 			if (position.IsMoveQuiet(m.move)) return false;
 			const int16_t captureScore = (m.move.IsPromotion()) ? 0 : t.History.GetCaptureHistoryScore(position, m.move);
-			return !StaticExchangeEval(position, m.move, -captureScore / 50);
+			return !StaticExchangeEval(position, m.move, -captureScore / 32);
 		}();
 		m.orderScore = CalculateOrderScore(t, position, m.move, level, ttMove, losingCapture, true);
 	}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.85";
+constexpr std::string_view Version = "dev 1.1.86";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.95 +- 1.55 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 50386 W: 11203 L: 10920 D: 28263
Penta | [130, 5910, 12854, 6145, 154]
https://zzzzz151.pythonanywhere.com/test/1944/
```

Renegade dev 1.1.86
Bench: 3421739