### PR TITLE
Reduce one ply more during null-move search

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -453,7 +453,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		if (depth >= 3 && eval >= beta && !position.IsPreviousMoveNull() && position.ZugzwangUnlikely()) {
 			TranspositionTable.Prefetch(position.Hash() ^ Zobrist[780]);
 			const int nmpReduction = [&] {
-				const int defaultReduction = 3 + depth / 3 + std::min((eval - beta) / 200, 3);
+				const int defaultReduction = 4 + depth / 3 + std::min((eval - beta) / 200, 3);
 				return std::min(defaultReduction, depth);
 			}();
 			position.PushNullMove();

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.86";
+constexpr std::string_view Version = "dev 1.1.87";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.95 +- 1.54 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 50490 W: 11255 L: 10972 D: 28263
Penta | [150, 5822, 12998, 6145, 130]
https://zzzzz151.pythonanywhere.com/test/1956/
```

Renegade dev 1.1.87
Bench: 3421752