### PR TITLE
On futility pruning set the score to the mean of alpha and bestscore

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -522,7 +522,10 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			}
 
 			// Performing futility pruning
-			if (isQuiet && order < 32678 && alpha < MateThreshold && futilityPrunable) break;
+			if (isQuiet && order < 32768 && alpha < MateThreshold && futilityPrunable) {
+				bestScore = (bestScore + alpha) / 2;
+				break;
+			}
 
 			// Main search SEE pruning
 			if (depth <= 5) {

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.88";
+constexpr std::string_view Version = "dev 1.1.89";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.65 +- 2.41 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20298 W: 4516 L: 4303 D: 11479
Penta | [40, 2289, 5303, 2452, 65]
https://zzzzz151.pythonanywhere.com/test/1966/
```

Renegade dev 1.1.89
Bench: 3775805