### PR TITLE
New transposition table replacement scheme

### DIFF
--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -39,7 +39,7 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 	const bool replaceable = [&] {
 		if (storedHash != candidateEntry.hash) return true;
 		if (scoreType == ScoreType::Exact) return true;
-		return UpdatingQuality(CurrentGeneration, depth) >= UpdatingQuality(candidateEntry.generation, candidateEntry.depth);
+		return depth + 3 + ttPv * 2 >= candidateEntry.depth;
 	}();
 
 	// Update the transposition entry

--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -11,7 +11,7 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 	if (std::abs(score) > MateEval) return;
 
 	const uint64_t key = hash & HashMask;
-	const uint16_t quality = RecordingQuality(CurrentGeneration, depth);
+	const int quality = RecordingQuality(CurrentGeneration, depth);
 	const uint32_t storedHash = GetStoredHash(hash);
 	const TranspositionCluster& cluster = Table[key];
 
@@ -23,10 +23,10 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 			if (entry.scoreType == ScoreType::Invalid) return i;
 			if (entry.hash == storedHash) return i;
 
-			const int quality = RecordingQuality(entry.generation, entry.depth);
-			if (quality < currentWorstQuality) {
+			const int entryQuality = RecordingQuality(entry.generation, entry.depth);
+			if (entryQuality < currentWorstQuality) {
 				currentWorst = i;
-				currentWorstQuality = quality;
+				currentWorstQuality = entryQuality;
 			};
 		};
 		assert(currentWorst != -1);
@@ -39,7 +39,7 @@ void Transpositions::Store(const uint64_t hash, const int depth, const int16_t s
 	const bool replaceable = [&] {
 		if (storedHash != candidateEntry.hash) return true;
 		if (scoreType == ScoreType::Exact) return true;
-		return quality >= RecordingQuality(candidateEntry.generation, candidateEntry.depth);
+		return UpdatingQuality(CurrentGeneration, depth) >= UpdatingQuality(candidateEntry.generation, candidateEntry.depth);
 	}();
 
 	// Update the transposition entry

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -64,5 +64,9 @@ private:
 	inline int RecordingQuality(const int generation, const int depth) const {
 		return generation * 2 + depth;
 	}
+
+	inline int UpdatingQuality(const int generation, const int depth) const {
+		return generation * 2 + depth;
+	}
 };
 

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -16,7 +16,7 @@ struct TranspositionEntry {
 	uint32_t hash = 0;
 	int16_t score = 0;
 	int16_t rawEval = 0;
-	uint16_t quality = 0;
+	uint16_t generation = 0;
 	uint8_t depth = 0;
 	uint8_t scoreType = ScoreType::Invalid;
 	uint16_t packedMove = 0;
@@ -51,7 +51,7 @@ public:
 private:
 	std::vector<TranspositionCluster> Table;
 	uint64_t HashMask;
-	uint16_t Age;
+	uint16_t CurrentGeneration;
 
 	inline uint64_t GetClusterIndex(const uint64_t hash) const {
 		return hash & HashMask;
@@ -59,6 +59,10 @@ private:
 
 	inline uint32_t GetStoredHash(const uint64_t hash) const {
 		return static_cast<uint32_t>((hash & 0xFFFFFFFF00000000) >> 32);
+	}
+
+	inline int RecordingQuality(const int generation, const int depth) const {
+		return generation * 2 + depth;
 	}
 };
 

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -64,9 +64,5 @@ private:
 	inline int RecordingQuality(const int generation, const int depth) const {
 		return generation * 2 + depth;
 	}
-
-	inline int UpdatingQuality(const int generation, const int depth) const {
-		return generation * 2 + depth;
-	}
 };
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.89";
+constexpr std::string_view Version = "dev 1.1.90";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 13.25 +- 5.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 4748 W: 1138 L: 957 D: 2653
Penta | [9, 486, 1205, 663, 11]
https://zzzzz151.pythonanywhere.com/test/1982/
```

Renegade dev 1.1.90
Bench: 3186754