### PR TITLE
Reduce less when improving

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -577,6 +577,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			if (t.CutoffCount[level] < 4) reduction -= 1;
 			if (std::abs(order) < 80000) reduction -= std::clamp(order / 16384, -2, 2);
 			if (cutNode) reduction += 1;
+			if (improving) reduction -= 1;
 			reduction = std::max(reduction, 0);
 
 			const int reducedDepth = std::clamp(depth - 1 - reduction, 0, depth - 1);

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.90";
+constexpr std::string_view Version = "dev 1.1.91";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 4.32 +- 2.68 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16824 W: 3834 L: 3625 D: 9365
Penta | [39, 1935, 4260, 2134, 44]
https://zzzzz151.pythonanywhere.com/test/1988/
```

Renegade dev 1.1.91
Bench: 3378461