### PR TITLE
Increase importance of the captured piece type in move ordering

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -913,8 +913,8 @@ int Search::CalculateOrderScore(const ThreadData& t, const Position& position, c
 
 	// Captures
 	if (capturedPieceType != PieceType::None) {
-		if (!losingCapture) return 600000 + values[capturedPieceType] * 8 + t.History.GetCaptureHistoryScore(position, m);
-		else return -200000 + values[capturedPieceType] * 8 + t.History.GetCaptureHistoryScore(position, m);
+		if (!losingCapture) return 600000 + values[capturedPieceType] * 16 + t.History.GetCaptureHistoryScore(position, m);
+		else return -200000 + values[capturedPieceType] * 16 + t.History.GetCaptureHistoryScore(position, m);
 	}
 
 	// Quiet killer moves

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.92";
+constexpr std::string_view Version = "dev 1.1.93";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.82 +- 2.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28872 W: 6571 L: 6337 D: 15964
Penta | [71, 3288, 7492, 3506, 79]
https://zzzzz151.pythonanywhere.com/test/2006/
```

Renegade dev 1.1.93
Bench: 3529791