### PR TITLE
Change the move count for when to start reducing

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -570,7 +570,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		
 		// Late-move reductions & principal variation search
-		if (depth >= 3 && (legalMoveCount >= (pvNode ? 6 : 4) + 2 * rootNode) && isQuiet) {
+		if (depth >= 3 && (legalMoveCount >= (pvNode ? 5 : 3) + 2 * rootNode) && isQuiet) {
 			
 			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 1;

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -570,7 +570,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		
 		// Late-move reductions & principal variation search
-		if (depth >= 3 && (legalMoveCount >= (pvNode ? 6 : 4)) && isQuiet) {
+		if (depth >= 3 && (legalMoveCount >= (pvNode ? 6 : 4) + 2 * rootNode) && isQuiet) {
 			
 			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 1;

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -570,7 +570,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		
 		// Late-move reductions & principal variation search
-		if (depth >= 3 && (legalMoveCount >= (pvNode ? 5 : 3) + 2 * rootNode) && isQuiet) {
+		if (depth >= 3 && (legalMoveCount >= (3 + pvNode * 2 + rootNode * 2)) && isQuiet) {
 			
 			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 1;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.93";
+constexpr std::string_view Version = "dev 1.1.94";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.42 +- 2.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22850 W: 5230 L: 5005 D: 12615
Penta | [63, 2665, 5751, 2876, 70]
https://zzzzz151.pythonanywhere.com/test/2008/
```

Renegade dev 1.1.94
Bench: 3656939