### PR TITLE
Change reverse futility pruning margins

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -465,7 +465,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Reverse futility pruning
 		if (depth <= 7 && !IsMateScore(beta)) {
-			const int rfpMargin = depth * 90 - improving * 90;
+			const int rfpMargin = depth * 95 - improving * 85;
 			if (eval - rfpMargin > beta) return (eval + beta) / 2;
 		}
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.97";
+constexpr std::string_view Version = "dev 1.1.98";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.60 +- 1.30 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 70632 W: 15813 L: 15488 D: 39331
Penta | [166, 8220, 18241, 8501, 188]
https://zzzzz151.pythonanywhere.com/test/2063/
```

Renegade dev 1.1.98
Bench: 4590926