### PR TITLE
Increase futility pruning margin when improving

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -488,7 +488,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Futility pruning
 		if (depth <= 5 && !IsMateScore(beta)) {
-			const int futilityMargin = 52 + depth * 110;
+			const int futilityMargin = 52 + depth * 110 + improving * 40;
 			futilityPrunable = (eval + futilityMargin < alpha);
 		}
 	}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.107";
+constexpr std::string_view Version = "dev 1.1.108";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.18 +- 1.69 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 41618 W: 9468 L: 9207 D: 22943
Penta | [91, 4807, 10771, 5030, 110]
https://zzzzz151.pythonanywhere.com/test/2401/
```

Renegade dev 1.1.108
Bench: 4575394