### PR TITLE
Replace refutation ordering with a simple bonus

### DIFF
--- a/Renegade/Movepicker.h
+++ b/Renegade/Movepicker.h
@@ -79,14 +79,12 @@ private:
 			else return -200000 + values[capturedPieceType] * 14 + hist.GetCaptureHistoryScore(pos, m);
 		}
 
-		// Quiet killer moves
-		if (m == killerMove) return 100000;
+		// Quiet moves, potentially apply a bonus for being a refutation (killer or counter move)
+		int historyScore = hist.GetHistoryScore(pos, m, movedPiece, level);
 
-		// Countermove heuristic
-		if (m == counterMove) return 99000;
+		if (m == killerMove) historyScore += 32768;
+		else if (m == counterMove) historyScore += 16384;
 
-		// Quiet moves
-		const int historyScore = hist.GetHistoryScore(pos, m, movedPiece, level);
 		return historyScore;
 	}
 

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -526,7 +526,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		else capturesTried.push(m);
 
 		// Moves loop pruning techniques
-		if (!pvNode && !IsLosingMateScore(bestScore) && (order < 90000) && !DatagenMode) {
+		if (!pvNode && !IsLosingMateScore(bestScore) && !DatagenMode) {
 
 			// Late-move pruning
 			if (depth <= 4 && isQuiet && !inCheck) {
@@ -589,7 +589,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			int reduction = LMRTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 1;
 			if (t.CutoffCount[level] < 4) reduction -= 1;
-			if (std::abs(order) < 80000) reduction -= std::clamp(order / 20200, -2, 2);
+			if (std::abs(order) < 150000) reduction -= std::clamp(order / 20200, -2, 2);
 			if (cutNode) reduction += 1;
 			if (improving) reduction -= 1;
 			reduction = std::max(reduction, 0);

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.110";
+constexpr std::string_view Version = "dev 1.1.111";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.53 +- 1.89 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33558 W: 7716 L: 7472 D: 18370
Penta | [77, 3888, 8628, 4086, 100]
https://zzzzz151.pythonanywhere.com/test/2416/
```

Renegade dev 1.1.111
Bench: 4109358