### PR TITLE
Tuned refutations (80k games @ 10+0.1)

### DIFF
--- a/Renegade/Movepicker.h
+++ b/Renegade/Movepicker.h
@@ -82,9 +82,9 @@ private:
 		// Quiet moves, potentially apply a bonus for being a refutation (killer or counter move)
 		int historyScore = hist.GetHistoryScore(pos, m, movedPiece, level);
 
-		if (m == killerMove) historyScore += 32768;
-		else if (m == counterMove) historyScore += 16384;
-		else if (m == positionalMove) historyScore += 16384;
+		if (m == killerMove) historyScore += 22000;
+		else if (m == counterMove) historyScore += 16000;
+		else if (m == positionalMove) historyScore += 16000;
 
 		return historyScore;
 	}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.115";
+constexpr std::string_view Version = "dev 1.1.116";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.64 +- 1.95 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31796 W: 7221 L: 6979 D: 17596
Penta | [82, 3685, 8125, 3921, 85]
https://zzzzz151.pythonanywhere.com/test/2499/
```

Renegade dev 1.1.116
Bench: 4565592