### PR TITLE
Apply move ordering bonuses as many times as failing high

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -53,15 +53,15 @@ Move Histories::GetPositionalMove(const Position& pos) const {
 
 // History heuristic ------------------------------------------------------------------------------
 
-template void Histories::UpdateQuietHistory<Bonus>(const Position&, const Move&, int, int);
-template void Histories::UpdateQuietHistory<Penalty>(const Position&, const Move&, int, int);
-template void Histories::UpdateCaptureHistory<Bonus>(const Position&, const Move&, int);
-template void Histories::UpdateCaptureHistory<Penalty>(const Position&, const Move&, int);
+template void Histories::UpdateQuietHistory<Bonus>(const Position&, const Move&, int, int, int);
+template void Histories::UpdateQuietHistory<Penalty>(const Position&, const Move&, int, int, int);
+template void Histories::UpdateCaptureHistory<Bonus>(const Position&, const Move&, int, int);
+template void Histories::UpdateCaptureHistory<Penalty>(const Position&, const Move&, int, int);
 
 template <bool bonus>
-void Histories::UpdateQuietHistory(const Position& position, const Move& m, const int level, const int depth) {
+void Histories::UpdateQuietHistory(const Position& position, const Move& m, const int level, const int depth, const int times) {
 	
-	const int delta = std::min(300 * depth, 2600) * (bonus ? 1 : -1);
+	const int delta = std::min(300 * depth, 2600) * times * (bonus ? 1 : -1);
 
 	// Main quiet history
 	const uint8_t movedPiece = position.GetPieceAt(m.from);
@@ -81,8 +81,8 @@ void Histories::UpdateQuietHistory(const Position& position, const Move& m, cons
 }
 
 template <bool bonus>
-void Histories::UpdateCaptureHistory(const Position& position, const Move& m, const int depth) {
-	const int delta = std::min(300 * depth, 2600) * (bonus ? 1 : -1);
+void Histories::UpdateCaptureHistory(const Position& position, const Move& m, const int depth, const int times) {
+	const int delta = std::min(300 * depth, 2600) * times * (bonus ? 1 : -1);
 	const uint8_t attackingPiece = position.GetPieceAt(m.from);
 	const uint8_t targetSquare = m.to;
 	const bool fromSquareThreatened = position.IsSquareThreatened(m.from);

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -62,6 +62,7 @@ template <bool bonus>
 void Histories::UpdateQuietHistory(const Position& position, const Move& m, const int level, const int depth, const int times) {
 	
 	const int delta = std::min(300 * depth, 2600) * times * (bonus ? 1 : -1);
+	//cout << times;
 
 	// Main quiet history
 	const uint8_t movedPiece = position.GetPieceAt(m.from);
@@ -84,6 +85,7 @@ template <bool bonus>
 void Histories::UpdateCaptureHistory(const Position& position, const Move& m, const int depth, const int times) {
 	const int delta = std::min(300 * depth, 2600) * times * (bonus ? 1 : -1);
 	const uint8_t attackingPiece = position.GetPieceAt(m.from);
+	//cout << times;
 	const uint8_t targetSquare = m.to;
 	const bool fromSquareThreatened = position.IsSquareThreatened(m.from);
 	const bool toSquareThreatened = position.IsSquareThreatened(m.to);

--- a/Renegade/Histories.h
+++ b/Renegade/Histories.h
@@ -31,8 +31,8 @@ public:
 	Move GetPositionalMove(const Position& pos) const;
 
 	// History heuristic:
-	template <bool bonus> void UpdateQuietHistory(const Position& position, const Move& m, const int level, const int depth);
-	template <bool bonus> void UpdateCaptureHistory(const Position& position, const Move& m, const int depth);
+	template <bool bonus> void UpdateQuietHistory(const Position& position, const Move& m, const int level, const int depth, const int times);
+	template <bool bonus> void UpdateCaptureHistory(const Position& position, const Move& m, const int depth, const int times);
 	int GetHistoryScore(const Position& position, const Move& m, const uint8_t movedPiece, const int level) const;
 	int GetCaptureHistoryScore(const Position& position, const Move& m) const;
 

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -675,8 +675,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		if (quietBestMove) quietsTried.pop(); // don't decrement for the current move
 		else capturesTried.pop();
 
-		for (const Move& qt : quietsTried) t.History.UpdateQuietHistory<Penalty>(position, qt, level, depth, failLowCount);
-		for (const Move& ct : capturesTried) t.History.UpdateCaptureHistory<Penalty>(position, ct, depth, failLowCount);
+		for (const Move& qt : quietsTried) t.History.UpdateQuietHistory<Penalty>(position, qt, level, depth, 1);
+		for (const Move& ct : capturesTried) t.History.UpdateCaptureHistory<Penalty>(position, ct, depth, 1);
 	}
 
 	// Update evaluation correction

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -613,7 +613,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		if (pvNode && (legalMoveCount == 1 || score > alpha)) {
 			score = -SearchRecursive(t, depth - 1 + extension + deepen, level + 1, -beta, -alpha, true, false);
-			failHighCount += (score > alpha);
+			failHighCount += (score >= beta);
 		}
 
 		position.PopMove();

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -580,6 +580,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		position.PushMove(m);
 		t.Nodes += 1;
 		int score = NoEval;
+		failHighCount = 0;
 		t.EvalState.PushState(position, m, movedPiece, capturedPiece);
 		bool deepen = false;
 
@@ -662,13 +663,13 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Increment history scores for the move causing the cutoff 
 		if (quietBestMove) {
-			t.History.UpdateQuietHistory<Bonus>(position, bestMove, level, depth, failLowCount);
+			t.History.UpdateQuietHistory<Bonus>(position, bestMove, level, depth, failHighCount);
 			t.History.SetKillerMove(bestMove, level);
 			t.History.SetPositionalMove(position, bestMove);
 			if (level > 0) t.History.SetCountermove(position.GetPreviousMove(1).move, bestMove);
 		}
 		else {
-			t.History.UpdateCaptureHistory<Bonus>(position, bestMove, depth, failLowCount);
+			t.History.UpdateCaptureHistory<Bonus>(position, bestMove, depth, failHighCount);
 		}
 
 		// Decrement history scores for all previously tried moves

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.116";
+constexpr std::string_view Version = "dev 1.1.117";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
A neat idea originally from Alexandria rewrite

```
Elo   | 3.35 +- 2.29 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22922 W: 5291 L: 5070 D: 12561
Penta | [48, 2640, 5882, 2825, 66]
https://zzzzz151.pythonanywhere.com/test/2526/
```

Renegade dev 1.1.117
Bench: 4735873