### PR TITLE
Don't SEE prune in main search when the destination square is safe

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -542,7 +542,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			}
 
 			// Main search SEE pruning
-			if (depth <= 5) {
+			if (depth <= 5 && position.IsSquareThreatened(m.to)) {
 				const int seeMargin = isQuiet ? (-50 * depth) : (-100 * depth);
 				if (!position.StaticExchangeEval(m, seeMargin)) continue;
 			}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.117";
+constexpr std::string_view Version = "dev 1.1.118";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.88 +- 1.50 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 52620 W: 12007 L: 11722 D: 28891
Penta | [117, 6074, 13659, 6327, 133]
https://zzzzz151.pythonanywhere.com/test/2548/
```

Renegade dev 1.1.118
Bench: 4635612