### PR TITLE
No longer write to TT and histories when aborting search

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -375,8 +375,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	assert(!pvNode || !cutNode);
 
 	// Check search limits
-	const bool aborting = ShouldAbort(t);
-	if (aborting) return NoEval;
+	if (ShouldAbort(t)) return NoEval;
 	t.InitPvLength(level);
 	if (level >= MaxDepth) return Evaluate(t, position);
 	if (level > t.SelDepth) t.SelDepth = level;
@@ -628,7 +627,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		if (score > bestScore) {
 			bestScore = score;
 
-			if (!aborting && pvNode) t.UpdatePvTable(m, level);
+			if (pvNode && !ShouldAbort(t)) t.UpdatePvTable(m, level);
 
 			// Raise alpha
 			if (score > alpha) {
@@ -654,6 +653,8 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		}
 		return inCheck ? LosingMateScore(level) : 0;
 	}
+
+	const bool aborting = ShouldAbort(t);
 
 	// Update search history and statistics when having a cutoff
 	if (bestScore >= beta && !aborting) {
@@ -708,8 +709,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 	assert(pvNode || beta - alpha == 1);
 
 	// Check search limits
-	const bool aborting = ShouldAbort(t);
-	if (aborting) return NoEval;
+	if (ShouldAbort(t)) return NoEval;
 	if (level > t.SelDepth) t.SelDepth = level;
 
 	// Probe the transposition table
@@ -770,7 +770,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 			}
 		}
 	}
-	if (!aborting) TranspositionTable.Store(hash, 0, bestScore, scoreType, rawEval, bestMove, level, ttPV);
+	if (!ShouldAbort(t)) TranspositionTable.Store(hash, 0, bestScore, scoreType, rawEval, bestMove, level, ttPV);
 	return bestScore;
 }
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.118";
+constexpr std::string_view Version = "dev 1.1.119";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixed 5k nodes as a stress test:
```
Elo   | 21.94 +- 7.80 (95%)
SPRT  | N=5000 Threads=1 Hash=2MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 4202 W: 1453 L: 1188 D: 1561
Penta | [133, 430, 777, 561, 200]
https://zzzzz151.pythonanywhere.com/test/2552/
```

Sanity test with 4 threads looks alright as well.

Renegade dev 1.1.119
Bench: 4635612