### PR TITLE
Prove checkmates in quiescence search

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -749,6 +749,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 		const auto& [m, order] = movePicker.Get();
 		if (!position.IsLegalMove(m)) continue;
 		if (!position.StaticExchangeEval(m, 0)) continue; // Quiescence search SEE pruning
+		if (bestScore > -MateThreshold && position.IsMoveQuiet(m)) continue;
 		t.Nodes += 1;
 
 		const uint8_t movedPiece = position.GetPieceAt(m.from);

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -721,20 +721,24 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 	if (found) ttMove = Move(ttEntry.packedMove);
 	const bool ttPV = pvNode || (found && ttEntry.ttPv);
 
-	// Update alpha-beta bounds
+	// Get node evaluation
+	const bool inCheck = position.IsInCheck();
 	const int rawEval = [&] {
-		if (found && !position.IsInCheck()) return ttEntry.rawEval;
+		if (inCheck) return static_cast<int16_t>(NoEval);
+		if (found) return ttEntry.rawEval;
 		return static_cast<int16_t>(Evaluate(t, position));
 	}();
-	const int staticEval = t.History.ApplyCorrection(position, rawEval);
+	const int staticEval = (!inCheck) ? t.History.ApplyCorrection(position, rawEval) : LosingMateScore(level);
+
+	// Check alpha-beta bounds
 	if (staticEval >= beta) return staticEval;
 	if (staticEval > alpha) alpha = staticEval;
-	if (level >= MaxDepth) return staticEval;
+	if (level >= MaxDepth) return inCheck ? 0 : staticEval;
 	if (position.IsDrawn(false)) return DrawEvaluation(t);
 
 	// Generate noisy moves and order them
 	MovePicker& movePicker = t.MovePickerStack[level];
-	movePicker.Initialize(MoveGen::Noisy, position, t.History, ttMove, level);
+	movePicker.Initialize(inCheck ? MoveGen::All : MoveGen::Noisy, position, t.History, ttMove, level);
 
 	// Search recursively
 	int bestScore = staticEval;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.120";
+constexpr std::string_view Version = "dev 1.1.121";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Now the engine (finally) generates quiet moves in quiescence search, and returns a checkmate value if no legal moves found

```
Elo   | 2.81 +- 2.68 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 16712 W: 3841 L: 3706 D: 9165
Penta | [40, 1941, 4253, 2088, 34]
https://zzzzz151.pythonanywhere.com/test/2653/
```

Renegade dev 1.1.121
Bench: 5120119