### PR TITLE
Net 31: Two-stage net with more data, 14 buckets and hl 1600

### DIFF
--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -17,24 +17,24 @@
 // for each piece: score += (15 - (manhattan distance to opponent's king)) * 6
 
 // Network constants
-#define NETWORK_NAME "renegade-net-30.bin"
+#define NETWORK_NAME "renegade-net-31.bin"
 
 constexpr int FeatureSize = 768;
-constexpr int HiddenSize = 1408;
+constexpr int HiddenSize = 1600;
 constexpr int Scale = 400;
 constexpr int QA = 255;
 constexpr int QB = 64;
 
-constexpr int InputBucketCount = 16;
+constexpr int InputBucketCount = 14;
 constexpr std::array<int, 32> InputBucketMap = {
 	 0,  1,  2,  3,
 	 4,  5,  6,  7,
 	 8,  8,  9,  9,
 	10, 10, 11, 11,
+	10, 10, 11, 11,
 	12, 12, 13, 13,
 	12, 12, 13, 13,
-	14, 14, 15, 15,
-	14, 14, 15, 15,
+	12, 12, 13, 13,
 };
 constexpr int OutputBucketCount = 8;
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.127";
+constexpr std::string_view Version = "dev 1.1.128";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -1,6 +1,10 @@
 /// Training parameters used to create Renegade's networks
 /// bullet version used: 98b58df (Add Copy operation for stopping gradients) from April 16, 2025
 
+/// Net 31 is trained in 2 stages (totally not by accident):
+/// - first 600 sb: cosine decay, wdl 0.2 -> 0.4
+/// - final 200 sb: continue the cosine decay, wdl fixed at 0.4
+
 #[allow(unused_imports)]
 use bullet_lib::{
     nn::{optimiser, Activation},
@@ -15,7 +19,7 @@ use bullet_lib::{
     },
 };
 
-const NET_ID: &str = "renegade-net-31-v1";
+const NET_ID: &str = "renegade-net-31";
 
 
 fn main() {
@@ -38,7 +42,7 @@ fn main() {
         .activate(Activation::SCReLU)
         .add_layer(1)
         .build();
-    trainer.load_from_checkpoint("checkpoints/renegade-net-31-v1-770");
+    //trainer.load_from_checkpoint("checkpoints/renegade-net-31-600");
     
     let schedule = TrainingSchedule {
         net_id: NET_ID.to_string(),
@@ -46,11 +50,11 @@ fn main() {
         steps: TrainingSteps {
             batch_size: 16384,
             batches_per_superbatch: 6104, // ~100 million positions
-            start_superbatch: 771,
-            end_superbatch: 800,
+            start_superbatch: 1, // <-- start from 601 for stage 2
+            end_superbatch: 600,
         },
         wdl_scheduler: wdl::LinearWDL {
-            start: 0.4,
+            start: 0.2,  // <-- change this for stage 2
             end: 0.4,
         },
         lr_scheduler: lr::Warmup {

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -1,5 +1,5 @@
 /// Training parameters used to create Renegade's networks
-/// bullet version used: cc122c3 (Improve working with loss functions) from January 14, 2025
+/// bullet version used: 98b58df (Add Copy operation for stopping gradients) from April 16, 2025
 
 #[allow(unused_imports)]
 use bullet_lib::{
@@ -15,7 +15,7 @@ use bullet_lib::{
     },
 };
 
-const NET_ID: &str = "renegade-net-30-gigachonky";
+const NET_ID: &str = "renegade-net-31-v1";
 
 
 fn main() {
@@ -28,17 +28,17 @@ fn main() {
              4,  5,  6,  7,
              8,  8,  9,  9,
             10, 10, 11, 11,
+            10, 10, 11, 11,
             12, 12, 13, 13,
             12, 12, 13, 13,
-            14, 14, 15, 15,
-            14, 14, 15, 15,
+            12, 12, 13, 13,
         ]))
         .output_buckets(outputs::MaterialCount::<8>::default())
-        .feature_transformer(1408)
+        .feature_transformer(1600)
         .activate(Activation::SCReLU)
         .add_layer(1)
         .build();
-    //trainer.load_from_checkpoint("checkpoints/renegade-net-x-y");
+    trainer.load_from_checkpoint("checkpoints/renegade-net-31-v1-770");
     
     let schedule = TrainingSchedule {
         net_id: NET_ID.to_string(),
@@ -46,18 +46,18 @@ fn main() {
         steps: TrainingSteps {
             batch_size: 16384,
             batches_per_superbatch: 6104, // ~100 million positions
-            start_superbatch: 1,
-            end_superbatch: 600,
+            start_superbatch: 771,
+            end_superbatch: 800,
         },
         wdl_scheduler: wdl::LinearWDL {
-            start: 0.2,
+            start: 0.4,
             end: 0.4,
         },
         lr_scheduler: lr::Warmup {
             inner: lr::CosineDecayLR {
                 initial_lr: 0.001,
                 final_lr: 0.001 * 0.3 * 0.3 * 0.3 * 0.3,
-                final_superbatch: 600,
+                final_superbatch: 800,
             },
             warmup_batches: 256
         },
@@ -81,7 +81,7 @@ fn main() {
     };
     
     let data_loader = loader::DirectSequentialDataLoader::new(
-        &["../nnue/data/240722_240821_240928_241010_frc241002"]
+        &["../nnue/data/240722_240821_240928_241010_241213_250418_frc241002"]
     );
 
     trainer.run(&schedule, &settings, &data_loader);


### PR DESCRIPTION
```
Elo   | 6.93 +- 3.58 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9980 W: 2501 L: 2302 D: 5177
Penta | [38, 1127, 2464, 1320, 41]
https://zzzzz151.pythonanywhere.com/test/2720/
```
```
Elo   | 8.07 +- 3.78 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7884 W: 1935 L: 1752 D: 4197
Penta | [7, 839, 2070, 1016, 10]
https://zzzzz151.pythonanywhere.com/test/2722/
```

Trained on 5.66 billion positions for 800 superbatches in total, and now also includes positions from 10k soft nodes datagen

Renegade dev 1.1.128
Bench: 4510003