### PR TITLE
Actually prove checkmates in quiescence search

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -735,7 +735,8 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 	// Check alpha-beta bounds
 	if (staticEval >= beta) return staticEval;
 	if (staticEval > alpha) alpha = staticEval;
-	if (level >= MaxDepth) return inCheck ? 0 : staticEval;
+
+	if (level >= MaxDepth) return inCheck ? DrawEvaluation(t) : staticEval;
 	if (position.IsDrawn(level)) return DrawEvaluation(t);
 
 	// Generate noisy moves and order them
@@ -750,7 +751,8 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 	while (movePicker.HasNext()) {
 		const auto& [m, order] = movePicker.Get();
 		if (!position.IsLegalMove(m)) continue;
-		if (!position.StaticExchangeEval(m, 0)) continue; // Quiescence search SEE pruning
+
+		if (bestScore > -MateThreshold && !position.StaticExchangeEval(m, 0)) continue; // Quiescence search SEE pruning
 		if (bestScore > -MateThreshold && position.IsMoveQuiet(m)) continue;
 		t.Nodes += 1;
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.131";
+constexpr std::string_view Version = "dev 1.1.132";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 0.81 +- 1.78 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 37522 W: 8570 L: 8482 D: 20470
Penta | [90, 4399, 9683, 4511, 78]
https://zzzzz151.pythonanywhere.com/test/2755/
```

Renegade dev 1.1.132
Bench: 5009878