### PR TITLE
Futility prune in quiescence search

### DIFF
--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.132";
+constexpr std::string_view Version = "dev 1.1.133";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.02 +- 2.14 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26216 W: 6034 L: 5806 D: 14376
Penta | [51, 3051, 6695, 3241, 70]
https://zzzzz151.pythonanywhere.com/test/2765/
```

Renegade dev 1.1.133
Bench: 4939303