### PR TITLE
Break out of qsearch moves loop when it makes sense

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -754,7 +754,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 		const auto& [m, order] = movePicker.Get();
 		if (!position.IsLegalMove(m)) continue;
 
-		if (inCheck && bestScore > -MateThreshold && (position.IsMoveQuiet(m) || order < -100000)) break;
+		if (inCheck && bestScore > -MateThreshold && order < 200000) break;
 
 		if (bestScore > -MateThreshold && !position.StaticExchangeEval(m, 0)) continue; // Quiescence search SEE pruning
 		if (!inCheck && alpha >= futilityScore && !position.StaticExchangeEval(m, 1)) {  // Quiescence search futility pruning

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -754,8 +754,9 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 		const auto& [m, order] = movePicker.Get();
 		if (!position.IsLegalMove(m)) continue;
 
+		if (inCheck && bestScore > -MateThreshold && (position.IsMoveQuiet(m) || order < -100000)) break;
+
 		if (bestScore > -MateThreshold && !position.StaticExchangeEval(m, 0)) continue; // Quiescence search SEE pruning
-		if (bestScore > -MateThreshold && position.IsMoveQuiet(m)) continue;
 		if (!inCheck && alpha >= futilityScore && !position.StaticExchangeEval(m, 1)) {  // Quiescence search futility pruning
 			if (bestScore < futilityScore) bestScore = futilityScore;
 			continue;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.1.133";
+constexpr std::string_view Version = "dev 1.1.134";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.47 +- 2.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 26202 W: 6050 L: 5939 D: 14213
Penta | [60, 2986, 6896, 3101, 58]
https://zzzzz151.pythonanywhere.com/test/2766/
```

Renegade dev 1.1.134
Bench: 4906738