### PR TITLE
Slightly increase the minimum search time

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -177,7 +177,7 @@ SearchConstraints Search::CalculateConstraints(const SearchParams params, const 
 		}
 		else {
 			// Time control with increment
-			minTime = static_cast<int>(myTime * 0.023 + myInc * 0.7);
+			minTime = static_cast<int>(myTime * 0.025 + myInc * 0.7);
 			maxTime = static_cast<int>(myTime * 0.25);
 		}
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "1.2.0";
+constexpr std::string_view Version = "dev 1.2.1";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.41 +- 1.14 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 81092 W: 18908 L: 18580 D: 43604
Penta | [153, 8495, 22935, 8797, 166]
https://zzzzz151.pythonanywhere.com/test/2883/
```

Bench: 4992978
Renegade dev 1.2.1