### PR TITLE
No longer save some scores in qsearch as exact

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -775,7 +775,6 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 			if (bestScore > alpha) {
 				alpha = bestScore;
 				bestMove = m;
-				scoreType = ScoreType::Exact;
 			}
 		}
 	}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.1";
+constexpr std::string_view Version = "dev 1.2.2";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.38 +- 1.11 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 96074 W: 22292 L: 21911 D: 51871
Penta | [239, 11199, 24747, 11646, 206]
https://zzzzz151.pythonanywhere.com/test/2939/
```

Renegade dev 1.2.2
Bench: 4877771