### PR TITLE
Fuse update operations for cached accumulators

### DIFF
--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -373,6 +373,11 @@ struct StaticVector {
 		count -= 1;
 	}
 
+	inline T pop_and_return() {
+		assert(count != 0);
+		return items[--count];
+	}
+
 	inline void clear() {
 		count = 0;
 	}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.2";
+constexpr std::string_view Version = "dev 1.2.3";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.96 +- 2.07 (95%)
SPRT  | 3.0+0.03s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 25248 W: 6214 L: 5999 D: 13035
Penta | [101, 2399, 7447, 2538, 139]
https://zzzzz151.pythonanywhere.com/test/3014/
```

Renegade dev 1.2.3
Bench: 4877771