### PR TITLE
Remove depth condition from main search SEE

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -534,7 +534,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			}
 
 			// Main search SEE pruning
-			if (depth <= 5 && position.IsSquareThreatened(m.to)) {
+			if (position.IsSquareThreatened(m.to)) {
 				const int seeMargin = isQuiet ? (-50 * depth) : (-100 * depth);
 				if (!position.StaticExchangeEval(m, seeMargin)) continue;
 			}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.3";
+constexpr std::string_view Version = "dev 1.2.4";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.37 +- 2.08 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 28058 W: 6564 L: 6453 D: 15041
Penta | [72, 3304, 7176, 3395, 82]
https://zzzzz151.pythonanywhere.com/test/3017/
```

Renegade dev 1.2.4
Bench: 4217178