### PR TITLE
Account for pinned pieces when calculating SEE

### DIFF
--- a/Renegade/Magics.h
+++ b/Renegade/Magics.h
@@ -7,12 +7,14 @@ extern void GenerateMagicTables();
 extern uint64_t GetRookAttacks(const uint8_t square, const uint64_t occupancy);
 extern uint64_t GetBishopAttacks(const uint8_t square, const uint64_t occupancy);
 extern uint64_t GetQueenAttacks(const uint8_t square, const uint64_t occupancy);
-extern uint64_t GetConnectingRay(const uint8_t from, const uint64_t to);
+extern uint64_t GetShortConnectingRay(const uint8_t from, const uint8_t to);
+extern uint64_t GetLongConnectingRay(const uint8_t from, const uint8_t to);
 
 // Attack lookup tables (generated at runtime)
 static MultiArray<uint64_t, 64, 4096> RookAttacks;
 static MultiArray<uint64_t, 64, 512> BishopAttacks;
-static MultiArray<uint64_t, 64, 64> ConnectingRays;
+static MultiArray<uint64_t, 64, 64> ShortConnectingRays;
+static MultiArray<uint64_t, 64, 64> LongConnectingRays;
 
 // Pregenerated random magic numbers
 // Think of: https://xkcd.com/221/

--- a/Renegade/Position.cpp
+++ b/Renegade/Position.cpp
@@ -881,7 +881,7 @@ GameState Position::GetGameState() const {
 // Static exchange evaluation (SEE) ---------------------------------------------------------------
 
 bool Position::StaticExchangeEval(const Move& move, const int threshold) const {
-	// Calculates the outcome of all captures targeting the move.to square
+	// Approximates the outcome of all captures targeting the move.to square
 	// Highly useful for pruning and for move ordering
 	// This iterative approach is the standard way of doing this with some additional code for pinned piece handling
 

--- a/Renegade/Position.cpp
+++ b/Renegade/Position.cpp
@@ -881,8 +881,9 @@ GameState Position::GetGameState() const {
 // Static exchange evaluation (SEE) ---------------------------------------------------------------
 
 bool Position::StaticExchangeEval(const Move& move, const int threshold) const {
-	// This is more or less the standard way of doing this
-	// The implementation follows Ethereal's method
+	// Calculates the outcome of all captures targeting the move.to square
+	// Highly useful for pruning and for move ordering
+	// This iterative approach is the standard way of doing this with some additional code for pinned piece handling
 
 	constexpr auto seeValues = std::array{ 0, 100, 300, 300, 500, 1000, 999999 };
 

--- a/Renegade/Position.cpp
+++ b/Renegade/Position.cpp
@@ -462,8 +462,8 @@ void Position::GenerateCastlingMoves(MoveList& moves) const {
 		constexpr uint8_t rookTo = (side == Side::White) ? F1 : F8;
 
 		const uint8_t rookSq = (side == Side::White) ? CastlingConfig.WhiteShortCastleRookSquare : CastlingConfig.BlackShortCastleRookSquare;
-		const uint64_t rayBetweenKingAndG = GetConnectingRay(kingSq, kingTo);
-		const uint64_t rayBetweenRookAndF = GetConnectingRay(rookSq, rookTo);
+		const uint64_t rayBetweenKingAndG = GetShortConnectingRay(kingSq, kingTo);
+		const uint64_t rayBetweenRookAndF = GetShortConnectingRay(rookSq, rookTo);
 		const uint64_t fakeOccupancy = occupancy ^ (SquareBit(kingSq) | SquareBit(rookSq));
 		const bool empty = !((rayBetweenKingAndG | rayBetweenRookAndF) & fakeOccupancy);
 
@@ -480,8 +480,8 @@ void Position::GenerateCastlingMoves(MoveList& moves) const {
 		constexpr uint8_t rookTo = (side == Side::White) ? D1 : D8;
 
 		const uint8_t rookSq = (side == Side::White) ? CastlingConfig.WhiteLongCastleRookSquare : CastlingConfig.BlackLongCastleRookSquare;
-		const uint64_t rayBetweenKingAndC = GetConnectingRay(kingSq, kingTo);
-		const uint64_t rayBetweenRookAndF = GetConnectingRay(rookSq, rookTo);
+		const uint64_t rayBetweenKingAndC = GetShortConnectingRay(kingSq, kingTo);
+		const uint64_t rayBetweenRookAndF = GetShortConnectingRay(rookSq, rookTo);
 		const uint64_t fakeOccupancy = occupancy ^ (SquareBit(kingSq) | SquareBit(rookSq));
 		const bool empty = !((rayBetweenKingAndC | rayBetweenRookAndF) & fakeOccupancy);
 
@@ -750,7 +750,7 @@ std::pair<uint64_t, uint64_t> Position::GetPinnedBitboard() const {
 
 	while (blackPotentialPinners) {
 		const uint8_t sq = Popsquare(blackPotentialPinners);
-		const uint64_t whitePiecesBetween = GetConnectingRay(sq, whiteKingSquare) & GetOccupancy(Side::White);
+		const uint64_t whitePiecesBetween = (GetShortConnectingRay(sq, whiteKingSquare) & ~SquareBit(sq) & ~SquareBit(whiteKingSquare)) & GetOccupancy(Side::White);
 		if (Popcount(whitePiecesBetween) == 1) whitePinned |= whitePiecesBetween;
 	}
 
@@ -761,7 +761,7 @@ std::pair<uint64_t, uint64_t> Position::GetPinnedBitboard() const {
 
 	while (whitePotentialPinners) {
 		const uint8_t sq = Popsquare(whitePotentialPinners);
-		const uint64_t blackPiecesBetween = GetOccupancy(Side::Black) & GetConnectingRay(sq, blackKingSquare);
+		const uint64_t blackPiecesBetween = (GetShortConnectingRay(sq, blackKingSquare) & ~SquareBit(sq) & ~SquareBit(blackKingSquare)) & GetOccupancy(Side::Black);
 		if (Popcount(blackPiecesBetween) == 1) blackPinned |= blackPiecesBetween;
 	}
 
@@ -916,7 +916,14 @@ bool Position::StaticExchangeEval(const Move& move, const int threshold) const {
 		SetBitFalse(occupancy, (turn == Side::White) ? move.to - 8 : move.to + 8);
 	}
 	turn = !turn;
-	uint64_t attackers = GetAttackersOfSquare(move.to, occupancy) & occupancy;
+
+	// Account for pinned pieces
+	const auto [whitePinned, blackPinned] = GetPinnedBitboard();
+	const uint64_t whiteAllowedPinned = whitePinned & GetLongConnectingRay(move.to, WhiteKingSquare());
+	const uint64_t blackAllowedPinned = blackPinned & GetLongConnectingRay(move.to, BlackKingSquare());
+	const uint64_t allowed = ~(whitePinned | blackPinned) | whiteAllowedPinned | blackAllowedPinned;
+
+	uint64_t attackers = GetAttackersOfSquare(move.to, occupancy) & occupancy & allowed;
 
 	// Pseudo-generating steps
 	while (true) {

--- a/Renegade/Position.h
+++ b/Renegade/Position.h
@@ -144,6 +144,7 @@ public:
 	}
 
 	uint64_t AttackersOfSquare(const bool attackingSide, const uint8_t square) const;
+	std::pair<uint64_t, uint64_t> GetPinnedBitboard() const;
 
 	inline uint64_t WhitePawnBits() const { return States.back().WhitePawnBits; }
 	inline uint64_t WhiteKnightBits() const { return States.back().WhiteKnightBits; }

--- a/Renegade/Position.h
+++ b/Renegade/Position.h
@@ -8,7 +8,8 @@
 uint64_t GetBishopAttacks(const uint8_t square, const uint64_t occupancy);
 uint64_t GetRookAttacks(const uint8_t square, const uint64_t occupancy);
 uint64_t GetQueenAttacks(const uint8_t square, const uint64_t occupancy);
-uint64_t GetConnectingRay(const uint8_t from, const uint64_t to);
+uint64_t GetShortConnectingRay(const uint8_t from, const uint8_t to);
+uint64_t GetLongConnectingRay(const uint8_t from, const uint8_t to);
 
 class Position
 {

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.5";
+constexpr std::string_view Version = "dev 1.2.6";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 5.06 +- 2.97 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14008 W: 3375 L: 3171 D: 7462
Penta | [33, 1611, 3535, 1769, 56]
https://zzzzz151.pythonanywhere.com/test/3062/
```

A really cool idea from pawnocchio

Renegade dev 1.2.6
Bench: 4408162