### PR TITLE
Increase the amount of half-move clock scaling

### DIFF
--- a/Renegade/Neural.cpp
+++ b/Renegade/Neural.cpp
@@ -120,8 +120,7 @@ int16_t NeuralEvaluate(const Position& position, const AccumulatorRepresentation
 	const int gamePhase = position.GetGamePhase();
 	output = output * (52 + std::min(24, gamePhase)) / 64;
 	// Scale according to a modified halfmove clock (max 80)
-	const int modifiedHalfmoveClock = std::max(position.CurrentState().HalfmoveClock - 20, 0);
-	output = output * (256 - modifiedHalfmoveClock) / 256;
+	output = output * (256 - position.CurrentState().HalfmoveClock) / 256;
 #endif
 
 	return std::clamp(output, -MateThreshold + 1, MateThreshold - 1);

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.26";
+constexpr std::string_view Version = "dev 1.2.27";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.61 +- 1.30 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 71890 W: 16855 L: 16522 D: 38513
Penta | [191, 8488, 18278, 8773, 215]
```

Renegade dev 1.2.27
Bench: 3912198