### PR TITLE
Net 34: regenerated DFRC dataset @ 20k soft nodes

### DIFF
--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -20,7 +20,7 @@
 // for each piece: score += (15 - (manhattan distance to opponent's king)) * 6
 
 // Network constants
-#define NETWORK_NAME "renegade-net-33.bin"
+#define NETWORK_NAME "renegade-net-34.bin"
 
 constexpr int FeatureSize = 768;
 constexpr int HiddenSize = 1600;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.27";
+constexpr std::string_view Version = "dev 1.2.28";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -31,7 +31,7 @@ use bullet_lib::{
 #[rustfmt::skip]
 fn main() {
     
-    const NET_ID: &str = "renegade_net_33a";
+    const NET_ID: &str = "renegade_net_34a";
     const HL_SIZE: usize = 1600;
     const NUM_OUTPUT_BUCKETS: usize = 8;
     const BUCKET_LAYOUT: [usize; 32] = [
@@ -116,7 +116,7 @@ fn main() {
     let settings = LocalSettings { threads: 4, test_set: None, output_directory: "checkpoints", batch_queue_size: 32 };
 
     let data_loader = DirectSequentialDataLoader::new(
-        &["../nnue/data/241010_241213_250418_251202_260112_frc241002"]
+        &["../nnue/data/241010_241213_250418_251202_260112_dfrc260126"]
     );
 
     trainer.run(&schedule, &settings, &data_loader);


### PR DESCRIPTION
Replace `frc241002` (544 million positions @ 5ksn) with `dfrc260126` (928 million positions @ 20ksn) in the training data mix. The total number of positions used in training has increased to 6.04 billion with the share of DFRC being up to around 15%.
(Note that `frc241002` is also DFRC data, despite what the naming might suggest.)


Destroys the previous version in DFRC:
```
Elo   | 42.26 +- 9.45 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 1702 W: 458 L: 252 D: 992
Penta | [10, 123, 406, 275, 37]
```

Decent gains in standard chess as well:
```
Elo   | 2.67 +- 1.98 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33700 W: 8418 L: 8159 D: 17123
Penta | [125, 4108, 8171, 4275, 171]
```

```
Elo   | 7.72 +- 3.71 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8322 W: 2036 L: 1851 D: 4435
Penta | [10, 896, 2164, 1081, 10]
```

Renegade dev 1.2.28
Bench: 3821494