### PR TITLE
Increase the default fraction of time spent on a move

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -177,7 +177,7 @@ SearchConstraints Search::CalculateConstraints(const SearchParams params, const 
 		}
 		else {
 			// Time control with increment
-			minTime = static_cast<int>(myTime * 0.025 + myInc * 0.7);
+			minTime = static_cast<int>(myTime * 0.033 + myInc * 0.7);
 			maxTime = static_cast<int>(myTime * 0.25);
 		}
 
@@ -288,7 +288,9 @@ void Search::SearchMoves(ThreadData& t) {
 			if (Constraints.SearchTimeMin != Constraints.SearchTimeMax) {
 				const Move& bestMove = t.PvTable[0][0];
 				const double bestMoveFraction = t.RootNodeCounts[bestMove.from][bestMove.to] / static_cast<double>(t.Nodes);
-				softTimeLimit = softTimeLimit * (t.RootDepth >= 10 ? (1.5 - bestMoveFraction) * 1.35 : 1.0);
+				if (t.RootDepth >= 10) {
+					softTimeLimit *= (1.5 - bestMoveFraction) * 1.35;
+				}
 			}
 			if (elapsedMs >= softTimeLimit) finished = true;
 		}

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.28";
+constexpr std::string_view Version = "dev 1.2.29";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.08 +- 2.11 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23916 W: 5557 L: 5345 D: 13014
Penta | [20, 2576, 6551, 2794, 17]
```

```
Elo   | 0.73 +- 1.88 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33130 W: 7803 L: 7733 D: 17594
Penta | [91, 3794, 8717, 3880, 83]
```

Renegade dev 1.2.29
Bench: 3821494