### PR TITLE
Consider best move stability in time management

### DIFF
--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.38";
+constexpr std::string_view Version = "dev 1.2.39";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.91 +- 2.07 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27120 W: 6404 L: 6177 D: 14539
Penta | [68, 3021, 7157, 3244, 70]
```

```
Elo   | 2.31 +- 1.74 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34926 W: 7983 L: 7751 D: 19192
Penta | [27, 3763, 9646, 4005, 22]
```

Renegade dev 1.2.39
Bench: 4238144