### PR TITLE
Net 35: replace the remaining 5k soft node data

### DIFF
--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -20,7 +20,7 @@
 // for each piece: score += (15 - (manhattan distance to opponent's king)) * 6
 
 // Network constants
-#define NETWORK_NAME "renegade-net-34.bin"
+#define NETWORK_NAME "renegade-net-35.bin"
 
 constexpr int FeatureSize = 768;
 constexpr int HiddenSize = 1600;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.39";
+constexpr std::string_view Version = "dev 1.2.40";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -1,7 +1,7 @@
 /// Training parameters used to create Renegade's networks
 /// bullet version used: e5f65c4 (Measure CPU dataloading throughput utility (#489)) from November 26, 2025
 
-/// Net 33 is trained in 2 stages (keeping the accidental schedule from net 31):
+/// Net 35 is trained in 2 stages (keeping the accidental schedule from net 31):
 /// - first 600 sb: cosine decay, wdl 0.4 -> 0.6
 /// - final 200 sb: continue the cosine decay, wdl fixed at 0.6
 
@@ -31,7 +31,7 @@ use bullet_lib::{
 #[rustfmt::skip]
 fn main() {
     
-    const NET_ID: &str = "renegade_net_34a";
+    const NET_ID: &str = "renegade_net_35a";
     const HL_SIZE: usize = 1600;
     const NUM_OUTPUT_BUCKETS: usize = 8;
     const BUCKET_LAYOUT: [usize; 32] = [
@@ -116,7 +116,7 @@ fn main() {
     let settings = LocalSettings { threads: 4, test_set: None, output_directory: "checkpoints", batch_queue_size: 32 };
 
     let data_loader = DirectSequentialDataLoader::new(
-        &["../nnue/data/241010_241213_250418_251202_260112_dfrc260126"]
+        &["../nnue/data/250418_251202_260112_260217_dfrc260126"]
     );
 
     trainer.run(&schedule, &settings, &data_loader);


### PR DESCRIPTION
Replace old datasets (`241010`, `241213`) with fresh data generated with a 10k soft node limit (`260217`). The total training dataset was around 6.30 billion positions.

```
Elo   | 6.79 +- 3.54 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10186 W: 2586 L: 2387 D: 5213
Penta | [41, 1131, 2559, 1312, 50]
```

```
Elo   | 11.67 +- 4.68 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 5420 W: 1364 L: 1182 D: 2874
Penta | [6, 576, 1370, 746, 12]
```

Renegade dev 1.2.40
Bench: 3773808