### PR TITLE
Net 36: switching over to viribinpacks & new 20ksn data

### DIFF
--- a/Renegade/Neural.h
+++ b/Renegade/Neural.h
@@ -20,7 +20,7 @@
 // for each piece: score += (15 - (manhattan distance to opponent's king)) * 6
 
 // Network constants
-#define NETWORK_NAME "renegade-net-35.bin"
+#define NETWORK_NAME "renegade-net-36.bin"
 
 constexpr int FeatureSize = 768;
 constexpr int HiddenSize = 1600;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.40";
+constexpr std::string_view Version = "dev 1.2.41";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -1,7 +1,7 @@
 /// Training parameters used to create Renegade's networks
-/// bullet version used: e5f65c4 (Measure CPU dataloading throughput utility (#489)) from November 26, 2025
+/// bullet version used: feab644 (Fix wdl scheduler checkpoint loading (#496)) from March 10, 2026
 
-/// Net 35 is trained in 2 stages (keeping the accidental schedule from net 31):
+/// Net 36 is trained in 2 stages (keeping the accidental schedule from net 31):
 /// - first 600 sb: cosine decay, wdl 0.4 -> 0.6
 /// - final 200 sb: continue the cosine decay, wdl fixed at 0.6
 
@@ -31,7 +31,7 @@ use bullet_lib::{
 #[rustfmt::skip]
 fn main() {
     
-    const NET_ID: &str = "renegade_net_35a";
+    const NET_ID: &str = "renegade_net_36a";
     const HL_SIZE: usize = 1600;
     const NUM_OUTPUT_BUCKETS: usize = 8;
     const BUCKET_LAYOUT: [usize; 32] = [
@@ -115,9 +115,21 @@ fn main() {
 
     let settings = LocalSettings { threads: 4, test_set: None, output_directory: "checkpoints", batch_queue_size: 32 };
 
-    let data_loader = DirectSequentialDataLoader::new(
-        &["../nnue/data/250418_251202_260112_260217_dfrc260126"]
-    );
+	let data_loader = {
+        let file_path = "251202_260112_260217_260312_dfrc260126.vf";
+        let buffer_size_mb = 2048;
+        let threads = 4;
+		let filter = viriformat::dataformat::Filter {
+            max_eval: 20000,
+            random_fen_skipping: true,
+            random_fen_skip_probability: 0.5,
+            ..Default::default()
+        };
+        ViriBinpackLoader::new(file_path, buffer_size_mb, threads, filter)
+    };
+	// let data_loader = DirectSequentialDataLoader::new(
+    //     &["../nnue/data/file_path"]
+    // );
 
     trainer.run(&schedule, &settings, &data_loader);
     

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -1,5 +1,5 @@
 /// Training parameters used to create Renegade's networks
-/// bullet version used: feab644 (Fix wdl scheduler checkpoint loading (#496)) from March 10, 2026
+/// bullet version used: 571f1a6 (Rewrite backend (#488)) from April 14, 2026
 
 /// Net 36 is trained in 2 stages (keeping the accidental schedule from net 31):
 /// - first 600 sb: cosine decay, wdl 0.4 -> 0.6
@@ -31,7 +31,7 @@ use bullet_lib::{
 #[rustfmt::skip]
 fn main() {
     
-    const NET_ID: &str = "renegade_net_36a";
+    const NET_ID: &str = "renegade_net_36b";
     const HL_SIZE: usize = 1600;
     const NUM_OUTPUT_BUCKETS: usize = 8;
     const BUCKET_LAYOUT: [usize; 32] = [
@@ -117,12 +117,12 @@ fn main() {
 
 	let data_loader = {
         let file_path = "251202_260112_260217_260312_dfrc260126.vf";
-        let buffer_size_mb = 2048;
-        let threads = 4;
+        let buffer_size_mb = 32768;
+        let threads = 8;
 		let filter = viriformat::dataformat::Filter {
             max_eval: 20000,
             random_fen_skipping: true,
-            random_fen_skip_probability: 0.5,
+            random_fen_skip_probability: 0.9,
             ..Default::default()
         };
         ViriBinpackLoader::new(file_path, buffer_size_mb, threads, filter)

--- a/renegade-net.rs
+++ b/renegade-net.rs
@@ -54,7 +54,7 @@ fn main() {
         .save_format(&[
             SavedFormat::id("l0w")
                 .transform(|store, weights| {
-                    let factoriser = store.get("l0f").values.repeat(NUM_INPUT_BUCKETS);
+                    let factoriser = store.get("l0f").values.f32().repeat(NUM_INPUT_BUCKETS);
                     weights.into_iter().zip(factoriser).map(|(a, b)| a + b).collect()
                 })
                 .round()


### PR DESCRIPTION
Replace dataset `250418` with `260312`. The new dataset is generated with 20k soft node limits, and has 30.75 million games (around 2.5-3 billion positions post-filtering). This finally completes the transition to viribinpacks in the training pipeline.

The gain is smaller than expected, which can be just normal saturation of the arch, or it is possible, that the training setup needs further tweaking. This is the first net that was trained on a server, instead of my personal laptop GPU.

```
Elo   | 2.94 +- 2.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29080 W: 7160 L: 6914 D: 15006
Penta | [125, 3443, 7179, 3647, 146]
```

```
Elo   | 2.85 +- 2.04 (95%)
SPRT  | 50.0+0.50s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27312 W: 6384 L: 6160 D: 14768
Penta | [29, 3109, 7154, 3337, 27]
```

Renegade dev 1.2.41
Bench: 3610228