### PR TITLE
Simplify aspiration window behavior 

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -248,17 +248,9 @@ void Search::SearchMoves(ThreadData& t) {
 
 			while (true) {
 				if (Aborting.load(std::memory_order_relaxed)) break;
-				int alpha, beta;
-				if (windowSize < 500) {
-					alpha = std::max(score - windowSize, NegativeInfinity);
-					beta = std::min(score + windowSize, PositiveInfinity);
-				}
-				else {
-					alpha = NegativeInfinity;
-					beta = PositiveInfinity;
-				}
 
-				//if (!settings.UciOutput) cout << "[" << alpha << ".." << beta << "] ";
+				int alpha = std::max(score - windowSize, NegativeInfinity);
+				int beta = std::min(score + windowSize, PositiveInfinity);
 
 				score = SearchRecursive<true>(t, searchDepth, 0, alpha, beta, false);
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.44";
+constexpr std::string_view Version = "dev 1.2.45";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 0.49 +- 1.54 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 46560 W: 10723 L: 10657 D: 25180
Penta | [86, 5123, 12812, 5157, 102]
```

Renegade dev 1.2.45
Bench: 4214898