### PR TITLE
Reset killer moves for the next ply instead of ply+2

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -497,9 +497,9 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	}
 
 	// Resetting killers and fail-high cutoff counts (in singular search we've already done these)
-	if (!singularSearch) {
-		if (level + 2 < MaxDepth) t.History.ResetKillerForPly(level + 2);
-		if (level + 1 < MaxDepth) t.CutoffCount[level + 1] = 0;
+	if (!singularSearch && level + 1 < MaxDepth) {
+		t.History.ResetKillerForPly(level + 1);
+		t.CutoffCount[level + 1] = 0;
 	}
 
 	// Iterate through legal moves

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.45";
+constexpr std::string_view Version = "dev 1.2.46";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 1.81 +- 1.45 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 56682 W: 13391 L: 13095 D: 30196
Penta | [143, 6593, 14553, 6929, 123]
```

Renegade dev 1.2.46
Bench: 3919424