### PR TITLE
Explicitly disallow qsfp for losing mate best scores

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -771,16 +771,19 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 		const auto& [m, order] = movePicker.next(position, t.History);
 		if (m == NullMove) break;
 
-		// When in check, no longer search quiet moves once we know we're not getting mated
-		if (inCheck && bestScore > -MateThreshold && order < MovePicker::MaxRegularQuietOrder) break;
+		if (bestScore > -MateThreshold) {
 
-		// Quiescence search SEE pruning
-		if (bestScore > -MateThreshold && !position.StaticExchangeEval(m, 0)) continue;
+			// When in check, no longer search quiet moves once we know we're not getting mated
+			if (inCheck && order < MovePicker::MaxRegularQuietOrder) break;
 
-		// Quiescence search futility pruning
-		if (!inCheck && alpha >= futilityScore && !position.StaticExchangeEval(m, 1)) {
-			if (bestScore < futilityScore) bestScore = futilityScore;
-			continue;
+			// Quiescence search SEE pruning
+			if (!position.StaticExchangeEval(m, 0)) continue;
+
+			// Quiescence search futility pruning
+			if (!inCheck && alpha >= futilityScore && !position.StaticExchangeEval(m, 1)) {
+				if (bestScore < futilityScore) bestScore = futilityScore;
+				continue;
+			}
 		}
 
 		t.Nodes += 1;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.46";
+constexpr std::string_view Version = "dev 1.2.47";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Equivalent behavior to main: `Penta | [0, 0, 4309, 0, 0]`

Renegade dev 1.2.47
Bench: 3919424
