### PR TITLE
Adjust late-move pruning move counts based on history

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -524,7 +524,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 			// Late-move pruning
 			if (depth <= 4 && isQuiet && !inCheck) {
-				const int lmpCount = 3 + depth * (depth - !improving);
+				const int lmpCount = 3 + depth * (depth - !improving) + (order / 8192);
 				if (legalMoveCount > lmpCount) break;
 			}
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -21,7 +21,7 @@ using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.49";
+constexpr std::string_view Version = "dev 1.2.50";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 2.32 +- 1.77 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 38346 W: 9159 L: 8903 D: 20284
Penta | [97, 4472, 9764, 4758, 82]
```

Renegade dev 1.2.50
Bench: 4421082