### PR TITLE
Remove the PV node term in the move count formula for LMR

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -600,7 +600,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Principal variation search & late-move reductions
 		// One ply equals 256 units in reduction calculations
-		if (depth >= 3 && (legalMoveCount >= (3 + rootNode * 2)) && isQuiet) {
+		if (depth >= 3 && (legalMoveCount >= 3 + 2 * rootNode) && isQuiet) {
 
 			int reduction = LateMoveReductionTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 313;

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -600,7 +600,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Principal variation search & late-move reductions
 		// One ply equals 256 units in reduction calculations
-		if (depth >= 3 && (legalMoveCount >= (3 + pvNode * 2 + rootNode * 2)) && isQuiet) {
+		if (depth >= 3 && (legalMoveCount >= (3 + rootNode * 2)) && isQuiet) {
 
 			int reduction = LateMoveReductionTable[std::min(depth, 31)][std::min(failLowCount, 31)];
 			if (!ttPV) reduction += 313;

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.51";
+constexpr std::string_view Version = "dev 1.2.52";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 0.53 +- 1.60 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 46346 W: 10724 L: 10653 D: 24969
Penta | [114, 5443, 11977, 5536, 103]
```

Renegade dev 1.2.52
Bench: 4393377