### PR TITLE
Perform history reductions based on up-to-date values

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -589,6 +589,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 		const uint64_t nodesBefore = t.Nodes;
 
 		TranspositionTable.Prefetch(position.ApproximateHashAfterMove(m));
+		const int quietHistory = isQuiet ? t.History.GetHistoryScore(position, m, movedPiece, level) : 0;
 		position.PushMove(m);
 		t.EvalState.PushState(position, m, movedPiece, capturedPiece);
 
@@ -608,7 +609,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			if (cutNode) reduction += 346;
 			if (improving) reduction -= 304;
 			if (givingCheck) reduction -= 205;
-			reduction -= std::clamp(order * 256 / 22610, -490, 490);
+			reduction -= std::clamp(quietHistory * 256 / 22610, -490, 490);
 
 			reduction = std::max(reduction / 256, 0);
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.52";
+constexpr std::string_view Version = "dev 1.2.53";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This also decouples the order score from the history score, refutation bonuses no longer count into the history.

```
Elo   | 2.77 +- 2.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29300 W: 6836 L: 6602 D: 15862
Penta | [52, 3418, 7489, 3626, 65]
```

Renegade dev 1.2.53
Bench: 4209688