### PR TITLE
Update history when best score < beta, but alpha was raised

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -676,17 +676,19 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 	const bool aborting = ShouldAbort(t);
 
 	// Update search history and statistics when having a cutoff
-	if (bestScore >= beta && !aborting) {
+	if (!bestMove.IsNull() && !aborting) {
 
-		if (level != 0) t.CutoffCount[level - 1] += 1;
+		if (!rootNode && bestScore >= beta) t.CutoffCount[level - 1] += 1;
 		const bool quietBestMove = position.IsMoveQuiet(bestMove);
 
 		// Increment history scores for the move causing the cutoff 
 		if (quietBestMove) {
 			t.History.UpdateQuietHistory<Bonus>(position, bestMove, level, depth, failHighCount);
-			t.History.SetKillerMove(bestMove, level);
-			t.History.SetPositionalMove(position, bestMove);
-			if (level > 0) t.History.SetCountermove(position.GetPreviousMove(1).move, bestMove);
+			if (bestScore >= beta) {
+				t.History.SetKillerMove(bestMove, level);
+				t.History.SetPositionalMove(position, bestMove);
+				if (!rootNode) t.History.SetCountermove(position.GetPreviousMove(1).move, bestMove);
+			}
 		}
 		else {
 			t.History.UpdateCaptureHistory<Bonus>(position, bestMove, depth, failHighCount);

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.57";
+constexpr std::string_view Version = "dev 1.2.58";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Elo   | 3.45 +- 2.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22560 W: 5536 L: 5312 D: 11712
Penta | [64, 2585, 5765, 2795, 71]
```

Renegade dev 1.2.58
Bench: 6163532