### PR TITLE
Update WDL model (15k games @ 50+0.5s)

### DIFF
--- a/Renegade/Utils.cpp
+++ b/Renegade/Utils.cpp
@@ -68,7 +68,7 @@ std::tuple<int, int, int> GetWDL(const int score, const int ply) {
 
 // Converts internal units into centipawns, following the convention of 100 cp = 50% chance of winning
 int ToCentipawns(const int score, const int ply) {
-	return score;
-	//const auto [a, b] = ModelWDLForPly(ply);
-	//return static_cast<int>(std::round(100.0 * static_cast<double>(score) / a));
+	if (std::abs(score) >= MateThreshold || score == 0) return score;
+	const auto [a, b] = ModelWDLForPly(ply);
+	return static_cast<int>(std::round(100.0 * static_cast<double>(score) / a));
 }

--- a/Renegade/Utils.cpp
+++ b/Renegade/Utils.cpp
@@ -68,7 +68,7 @@ std::tuple<int, int, int> GetWDL(const int score, const int ply) {
 
 // Converts internal units into centipawns, following the convention of 100 cp = 50% chance of winning
 int ToCentipawns(const int score, const int ply) {
-	if (std::abs(score) >= MateThreshold || score == 0) return score;
-	const auto [a, b] = ModelWDLForPly(ply);
-	return static_cast<int>(std::round(100.0 * static_cast<double>(score) / a));
+	return score;
+	//const auto [a, b] = ModelWDLForPly(ply);
+	//return static_cast<int>(std::round(100.0 * static_cast<double>(score) / a));
 }

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -35,9 +35,9 @@ constexpr int MaxMoveCount = 256;
 
 // Pawn value normalization and WDL reporting:
 // (calculated with https://github.com/official-stockfish/WDL_model using Renegade's own games)
-constexpr int PawnNormalizationForMove32 = 283;
-constexpr std::array<double, 4> as = { -3.81800249, 23.69152927, 9.92151176, 253.21857231 };
-constexpr std::array<double, 4> bs = { -7.05174858, 50.55474509, -104.53363448, 126.58685682 };
+constexpr int PawnNormalizationForMove32 = 363;
+constexpr std::array<double, 4> as = { -0.35774711, 3.38012218, 33.86182325, 326.40775872 };
+constexpr std::array<double, 4> bs = { -9.52324742, 66.39579560, -146.48812371, 166.39300727 };
 static_assert(static_cast<int>(std::reduce(as.begin(), as.end())) == PawnNormalizationForMove32);
 
 std::tuple<int, int, int> GetWDL(const int score, const int ply);

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.58";
+constexpr std::string_view Version = "dev 1.2.59";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
```
Retained (W,D,L) = (143908, 1319200, 156182) positions.
const int NormalizeToPawnValue = 363;
Corresponding spread = 76;
Corresponding normalized spread = 0.21133809945096277;
Draw rate at 0.0 eval at move 32 = 0.9825319138788309;
p_a = ((-0.358 * x / 32 + 3.380) * x / 32 + 33.862) * x / 32 + 326.408
p_b = ((-9.523 * x / 32 + 66.396) * x / 32 + -146.488) * x / 32 + 166.393
    constexpr double as[] = {-0.35774711, 3.38012218, 33.86182325, 326.40775872};
    constexpr double bs[] = {-9.52324742, 66.39579560, -146.48812371, 166.39300727};
```

Renegade dev 1.2.59
Bench: 6163532