### PR TITLE
True support for non-power-of-2 transposition table sizes

### DIFF
--- a/Renegade/Engine.cpp
+++ b/Renegade/Engine.cpp
@@ -264,6 +264,7 @@ void Engine::Start() {
 		if (parts[0] == "hash") {
 			Settings::Hash = std::stoi(parts[1]);
 			SearchThreads.TranspositionTable.SetSize(Settings::Hash, Settings::Threads);
+			SearchThreads.ResetState(false);
 			cout << "-> Set hash size to " << Settings::Hash << endl;
 			continue;
 		}

--- a/Renegade/Transpositions.cpp
+++ b/Renegade/Transpositions.cpp
@@ -129,12 +129,10 @@ void Transpositions::IncreaseAge() {
 
 void Transpositions::SetSize(const int megabytes, const int threadCount) {
 	assert(megabytes > 0);
-	const uint64_t theoreticalClusterCount = static_cast<uint64_t>(megabytes) * 1024 * 1024 / sizeof(TranspositionCluster);
-	const uint64_t actualClusterCount = std::bit_floor(theoreticalClusterCount);
-
-	if (TableSize != actualClusterCount) {
+	const uint64_t clusterCount = static_cast<uint64_t>(megabytes) * 1024 * 1024 / sizeof(TranspositionCluster);
+	if (TableSize != clusterCount) {
 		FreeTable();
-		AllocateTable(actualClusterCount);
+		AllocateTable(clusterCount);
 	}
 	Clear(threadCount);
 }

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -67,6 +67,7 @@ private:
 
 	inline uint64_t GetClusterIndex(const uint64_t hash) const {
 		// Fixed-point fractional multiplication
+		using uint128_t = unsigned __int128;
 		assert(TableSize != 0);
 		return static_cast<uint64_t>((static_cast<uint128_t>(hash) * static_cast<uint128_t>(TableSize)) >> 64);
 	}

--- a/Renegade/Transpositions.h
+++ b/Renegade/Transpositions.h
@@ -66,8 +66,9 @@ private:
 	void FreeTable();
 
 	inline uint64_t GetClusterIndex(const uint64_t hash) const {
-		assert((TableSize & (TableSize - 1)) == 0);
-		return hash & (TableSize - 1);
+		// Fixed-point fractional multiplication
+		assert(TableSize != 0);
+		return static_cast<uint64_t>((static_cast<uint128_t>(hash) * static_cast<uint128_t>(TableSize)) >> 64);
 	}
 
 	inline uint32_t GetStoredHash(const uint64_t hash) const {

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -20,6 +20,7 @@ using std::cin;
 using std::endl;
 using std::get;
 using Clock = std::chrono::high_resolution_clock;
+using uint128_t = unsigned __int128;
 
 constexpr std::string_view Version = "dev 1.2.48";
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -18,9 +18,8 @@
 using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
-using uint128_t = unsigned __int128;
 
-constexpr std::string_view Version = "dev 1.2.59";
+constexpr std::string_view Version = "dev 1.2.60";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Testing showed a tiny regression (~1 elo) at STC, but it's probably alright.

Renegade dev 1.2.60
Bench: 5713676