### PR TITLE
Give history bonuses and penalites to the right moves

### DIFF
--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -90,6 +90,7 @@ void Histories::UpdateQuietHistory(const Position& position, const Move& m, cons
 template <bool bonus>
 void Histories::UpdateCaptureHistory(const Position& position, const Move& m, const int depth, const int times) {
 	const int delta = bonus ? std::min(303 * depth, 2950) * times : -std::min(274 * depth, 2950);
+	//if (times == 0) std::cout << bonus << " " << times << std::endl;
 	const uint8_t attackingPiece = position.GetPieceAt(m.from);
 	const uint8_t targetSquare = m.to;
 	const bool fromSquareThreatened = position.IsSquareThreatened(m.from);

--- a/Renegade/Histories.cpp
+++ b/Renegade/Histories.cpp
@@ -90,7 +90,6 @@ void Histories::UpdateQuietHistory(const Position& position, const Move& m, cons
 template <bool bonus>
 void Histories::UpdateCaptureHistory(const Position& position, const Move& m, const int depth, const int times) {
 	const int delta = bonus ? std::min(303 * depth, 2950) * times : -std::min(274 * depth, 2950);
-	//if (times == 0) std::cout << bonus << " " << times << std::endl;
 	const uint8_t attackingPiece = position.GetPieceAt(m.from);
 	const uint8_t targetSquare = m.to;
 	const bool fromSquareThreatened = position.IsSquareThreatened(m.from);

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -682,7 +682,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 		// Increment history scores for the move causing the cutoff 
 		if (quietBestMove) {
-			t.History.UpdateQuietHistory<Bonus>(position, bestMove, level, depth, failHighCount);
+			t.History.UpdateQuietHistory<Bonus>(position, bestMove, level, depth, std::max(failHighCount, 1));
 			if (bestScore >= beta) {
 				t.History.SetKillerMove(bestMove, level);
 				t.History.SetPositionalMove(position, bestMove);
@@ -690,15 +690,16 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 			}
 		}
 		else {
-			t.History.UpdateCaptureHistory<Bonus>(position, bestMove, depth, failHighCount);
+			t.History.UpdateCaptureHistory<Bonus>(position, bestMove, depth, std::max(failHighCount, 1));
 		}
 
-		// Decrement history scores for all previously tried moves
-		if (quietBestMove) quietsTried.pop(); // don't decrement for the current move
-		else capturesTried.pop();
-
-		for (const Move& qt : quietsTried) t.History.UpdateQuietHistory<Penalty>(position, qt, level, depth, 1);
-		for (const Move& ct : capturesTried) t.History.UpdateCaptureHistory<Penalty>(position, ct, depth, 1);
+		// Decrement history scores for all other moves
+		for (const Move& qt : quietsTried) {
+			if (qt != bestMove) t.History.UpdateQuietHistory<Penalty>(position, qt, level, depth, 1);
+		}
+		for (const Move& ct : capturesTried) {
+			if (ct != bestMove) t.History.UpdateCaptureHistory<Penalty>(position, ct, depth, 1);
+		}
 	}
 
 	// Update evaluation correction history

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.61";
+constexpr std::string_view Version = "dev 1.2.62";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
It is no longer correct to assume that the last move is also the best move, since histories are now also updated when alpha is raised, but no cutoffs happen

```
Elo   | 1.34 +- 2.08 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 28606 W: 6877 L: 6767 D: 14962
Penta | [70, 3448, 7185, 3502, 98]
```

Renegade dev 1.2.62
Bench: 5601468