### PR TITLE
Rewritten PV line handling

### DIFF
--- a/Renegade/Move.h
+++ b/Renegade/Move.h
@@ -134,6 +134,16 @@ struct ScoredMove {
 	int32_t orderScore;
 };
 
+struct PrincipalVariation {
+	StaticVector<Move, MaxDepth + 1> pvLine{};
+
+	void set_move_and_child(const Move& move, const PrincipalVariation& childList) {
+		pvLine.clear();
+		pvLine.push(move);
+		for (const Move& childMove : childList.pvLine) pvLine.push(childMove);
+	}
+};
+
 // Move list --------------------------------------------------------------------------------------
 
 struct MoveList : StaticVector<ScoredMove, MaxMoveCount> {

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -270,7 +270,7 @@ void Search::SearchMoves(ThreadData& t) {
 
 		}
 
-		const Move& bestMove = t.PVTable[0][0];
+		const Move& bestMove = t.PrincipalVariationTable[0].pvLine[0];
 		if (previousBestMove == bestMove) {
 			bestMoveStability += 1;
 		}
@@ -333,7 +333,7 @@ void Search::SearchMoves(ThreadData& t) {
 	// Main thread should wait others finishing before displaying the final best move
 	if (t.IsMainThread() && !t.singlethreaded) {
 		Aborting.store(true);
-		while (ActiveThreadCount.load() > 1) { std::this_thread::yield(); };
+		while (ActiveThreadCount.load() > 1) { std::this_thread::yield(); }
 		PrintInfo(AggregateThreadResults());
 	}
 }
@@ -376,7 +376,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 	// Check search limits
 	if (ShouldAbort(t)) return NoEval;
-	t.InitPVLength(level);
+	if (pvNode) t.PrincipalVariationTable[level].pvLine.clear();
 	if (level >= MaxDepth) return Evaluate(t, position);
 	if (level > t.SelDepth) t.SelDepth = level;
 	const bool tooDeep = level >= t.RootDepth * 2;
@@ -649,10 +649,17 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 
 			// Raise alpha
 			if (score > alpha) {
-				if (pvNode && !ShouldAbort(t)) t.UpdatePVTable(m, level);
 				bestMove = m;
 				scoreType = ScoreType::Exact;
 				alpha = score;
+
+				if (pvNode && !ShouldAbort(t)) {
+					t.PrincipalVariationTable[level].pvLine.clear();
+					t.PrincipalVariationTable[level].pvLine.push(m);
+					for (const Move& childMove : t.PrincipalVariationTable[level + 1].pvLine) {
+						t.PrincipalVariationTable[level].pvLine.push(childMove);
+					}
+				}
 			}
 
 			// Fail-high
@@ -732,6 +739,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 
 	// Check search limits
 	if (ShouldAbort(t)) return NoEval;
+	if (pvNode) t.PrincipalVariationTable[level].pvLine.clear();
 	if (level > t.SelDepth) t.SelDepth = level;
 
 	// Probe the transposition table
@@ -800,14 +808,23 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 
 		if (score > bestScore) {
 			bestScore = score;
-			if (bestScore >= beta) {
-				scoreType = ScoreType::LowerBound;
-				bestMove = m;
-				break;
-			}
+			
 			if (bestScore > alpha) {
 				alpha = bestScore;
 				bestMove = m;
+
+				if (pvNode && !ShouldAbort(t)) {
+					t.PrincipalVariationTable[level].pvLine.clear();
+					t.PrincipalVariationTable[level].pvLine.push(m);
+					for (const Move& childMove : t.PrincipalVariationTable[level + 1].pvLine) {
+						t.PrincipalVariationTable[level].pvLine.push(childMove);
+					}
+				}
+			}
+
+			if (bestScore >= beta) {
+				scoreType = ScoreType::LowerBound;
+				break;
 			}
 		}
 	}
@@ -826,31 +843,15 @@ int Search::DrawEvaluation(const ThreadData& t) const {
 
 // PV table ---------------------------------------------------------------------------------------
 
-void ThreadData::InitPVLength(const int level) {
-	PVLength[level] = level;
-}
-
-void ThreadData::UpdatePVTable(const Move& move, const int level) {
-	PVTable[level][level] = move;
-	for (int nextLevel = level + 1; nextLevel < PVLength[level + 1]; nextLevel++) {
-		PVTable[level][nextLevel] = PVTable[level + 1][nextLevel];
-	}
-	PVLength[level] = PVLength[level + 1];
-}
-
 std::vector<Move> ThreadData::GeneratePVLine() const {
 	std::vector<Move> list;
-	list.reserve(PVLength[0]);
-
-	for (int i = 0; i < PVLength[0]; i++) {
-		const Move& m = PVTable[0][i];
-		if (m.IsNull()) break;
+	list.reserve(PrincipalVariationTable[0].pvLine.size());
+	for (const Move& m : PrincipalVariationTable[0].pvLine) {
 		list.push_back(m);
 	}
 	return list;
 }
 
 void ThreadData::ResetPVTable() {
-	std::memset(&PVTable, 0, sizeof(PVTable));
-	std::fill(PVLength.begin(), PVLength.end(), 0);
+	std::memset(&PrincipalVariationTable, 0, sizeof(PrincipalVariationTable));
 }

--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -654,11 +654,7 @@ int Search::SearchRecursive(ThreadData& t, int depth, const int level, int alpha
 				alpha = score;
 
 				if (pvNode && !ShouldAbort(t)) {
-					t.PrincipalVariationTable[level].pvLine.clear();
-					t.PrincipalVariationTable[level].pvLine.push(m);
-					for (const Move& childMove : t.PrincipalVariationTable[level + 1].pvLine) {
-						t.PrincipalVariationTable[level].pvLine.push(childMove);
-					}
+					t.PrincipalVariationTable[level].set_move_and_child(m, t.PrincipalVariationTable[level + 1]);
 				}
 			}
 
@@ -814,11 +810,7 @@ int Search::SearchQuiescence(ThreadData& t, const int level, int alpha, int beta
 				bestMove = m;
 
 				if (pvNode && !ShouldAbort(t)) {
-					t.PrincipalVariationTable[level].pvLine.clear();
-					t.PrincipalVariationTable[level].pvLine.push(m);
-					for (const Move& childMove : t.PrincipalVariationTable[level + 1].pvLine) {
-						t.PrincipalVariationTable[level].pvLine.push(childMove);
-					}
+					t.PrincipalVariationTable[level].set_move_and_child(m, t.PrincipalVariationTable[level + 1]);
 				}
 			}
 

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -21,10 +21,6 @@
 
 enum class ThreadAction { Sleep, Search, Exit };
 
-struct PrincipalVariation {
-	StaticVector<Move, MaxDepth + 1> pvLine{};
-};
-
 class alignas(64) ThreadData {
 public:
 	void ResetStatistics();

--- a/Renegade/Search.h
+++ b/Renegade/Search.h
@@ -21,6 +21,10 @@
 
 enum class ThreadAction { Sleep, Search, Exit };
 
+struct PrincipalVariation {
+	StaticVector<Move, MaxDepth + 1> pvLine{};
+};
+
 class alignas(64) ThreadData {
 public:
 	void ResetStatistics();
@@ -28,14 +32,12 @@ public:
 	int RootDepth = 0, SelDepth = 0;
 	int64_t Nodes = 0;
 	Histories History;
-	MultiArray<Move, MaxDepth + 1, MaxDepth + 1> PVTable;
+	MultiArray<PrincipalVariation, MaxDepth + 1> PrincipalVariationTable;
 	std::array<int, MaxDepth + 1> PVLength;
 	EvaluationState EvalState;
 	MultiArray<uint64_t, 64, 64> RootNodeCounts;
 
 	// PV table
-	void UpdatePVTable(const Move& move, const int level);
-	void InitPVLength(const int level);
 	std::vector<Move> GeneratePVLine() const;
 	void ResetPVTable();
 

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.63";
+constexpr std::string_view Version = "dev 1.2.64";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This comes with a minor slowdown (~2 elo at VSTC), but it's good for correctness, passes Stockfish's matetrack suite without warnings. PV lines now also include moves from qsearch.

Renegade dev 1.2.64
Bench: 4758615