### PR TITLE
No longer do full SEE calculations for castling moves

### DIFF
--- a/Renegade/Position.cpp
+++ b/Renegade/Position.cpp
@@ -1181,6 +1181,9 @@ bool Position::StaticExchangeEval(const Move& move, const int threshold) const {
 
 	constexpr auto seeValues = std::array{ 0, 100, 300, 300, 500, 1000, 999999 };
 
+	// Castling is not handled
+	if (move.IsCastling()) return threshold <= 0;
+
 	// Get the initial piece
 	uint8_t victim = TypeOfPiece(GetPieceAt(move.from));
 	if (move.IsPromotion()) victim = move.GetPromotionPieceType();
@@ -1189,7 +1192,6 @@ bool Position::StaticExchangeEval(const Move& move, const int threshold) const {
 	int estimatedMoveValue = seeValues[TypeOfPiece(GetPieceAt(move.to))];
 	if (move.IsPromotion()) estimatedMoveValue += seeValues[move.GetPromotionPieceType()] - seeValues[PieceType::Pawn];
 	else if (move.flag == MoveFlag::EnPassantPerformed) estimatedMoveValue = seeValues[PieceType::Pawn];
-	else if (move.IsCastling()) estimatedMoveValue = 0;
 
 	// Handle trivial cases (losing the piece for nothing still above / having initial gain below threshold)
 	int score = -threshold;
@@ -1198,7 +1200,7 @@ bool Position::StaticExchangeEval(const Move& move, const int threshold) const {
 	score -= seeValues[victim];
 	if (score >= 0) return true;
 
-	// Lookups (should be optimized) 
+	// Lookups
 	const uint64_t whitePieces = GetOccupancy(Side::White);
 	const uint64_t blackPieces = GetOccupancy(Side::Black);
 	const uint64_t rookLikeSliders = WhiteRookBits() | BlackRookBits() | WhiteQueenBits() | BlackQueenBits();

--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -19,7 +19,7 @@ using std::cout;
 using std::endl;
 using Clock = std::chrono::high_resolution_clock;
 
-constexpr std::string_view Version = "dev 1.2.66";
+constexpr std::string_view Version = "dev 1.2.67";
 
 // Evaluation helpers -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This seemingly was never updated when KxR castling encoding was introduced, it is not very useful to do these based on incorrect bitboards.

```
Elo   | 1.29 +- 2.05 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 29188 W: 7007 L: 6899 D: 15282
Penta | [87, 3452, 7411, 3554, 90]
```

Renegade dev 1.2.67
Bench: 5112160