### PR TITLE
Fixing build

### DIFF
--- a/Renegade/Utils.h
+++ b/Renegade/Utils.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <optional>
 
 using std::cout;
 using std::endl;


### PR DESCRIPTION
Fixing the following build error:
```
clang++ -std=c++20 -O3 -flto -funroll-loops -fno-exceptions -DNDEBUG -Wall -Wextra -pthread -march=native -mtune=native -MMD -MP -c Board.cpp -o Board.o
In file included from Board.cpp:1:
In file included from ./Board.h:2:
In file included from ./Move.h:2:
./Utils.h:304:6: error: no template named 'optional' in namespace 'std'
std::optional<bool> ParseUCIBoolean(const std::string_view str);
~~~~~^
1 error generated.
make: *** [makefile:82: Board.o] Error 1
```