### PR TITLE
Fixing build on Android

### DIFF
--- a/Renegade/Search.cpp
+++ b/Renegade/Search.cpp
@@ -353,7 +353,7 @@ Results Search::AggregateThreadResults() const {
 
 	// Other data
 	const auto currentTime = Clock::now();
-	const uint64_t elapsedNs = std::max((currentTime - StartSearchTime).count(), int64_t{1});
+	const uint64_t elapsedNs = std::max<int64_t>((currentTime - StartSearchTime).count(), int64_t{1});
 	const uint64_t elapsedMs = elapsedNs / 1'000'000;
 	sumResult.time = elapsedMs;
 	sumResult.nps = static_cast<uint64_t>(sumResult.nodes * 1e9 / elapsedNs);


### PR DESCRIPTION
Fixing the following error, which happens when building with Android NDK:
```
C/C++: C:\Users\Jirka\AppData\Local\Android\Sdk\ndk\28.2.13676358\toolchains\llvm\prebuilt\windows-x86_64\bin\clang++.exe --target=x86_64-none-linux-android28 --sysroot=C:/Users/Jirka/AppData/Local/Android/Sdk/ndk/28.2.13676358/toolchains/llvm/prebuilt/windows-x86_64/sysroot   -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -fno-limit-debug-info  -fPIC -IC:/Users/Jirka/AndroidStudioProjects/Renegade/app/src/main/cpp/Renegade/Renegade -std=gnu++20 -MD -MT Renegade/Renegade/CMakeFiles/MyLibrary.dir/Search.cpp.o -MF Renegade\Renegade\CMakeFiles\MyLibrary.dir\Search.cpp.o.d -o Renegade/Renegade/CMakeFiles/MyLibrary.dir/Search.cpp.o -c C:/Users/Jirka/AndroidStudioProjects/Renegade/app/src/main/cpp/Renegade/Renegade/Search.cpp
C/C++: C:/Users/Jirka/AndroidStudioProjects/Renegade/app/src/main/cpp/Renegade/Renegade/Search.cpp:356:29: error: no matching function for call to 'max'
C/C++:   356 |         const uint64_t elapsedNs = std::max((currentTime - StartSearchTime).count(), int64_t{1});
C/C++:       |                                    ^~~~~~~~
```

Should solve #189 